### PR TITLE
add zed editor and clangd settings

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -2,3 +2,4 @@ bazel-rigid_geometric_algebra
 bazel-bin
 bazel-out
 bazel-testlog
+external

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,21 @@
+CompileFlags:
+    CompilationDatabase: ./
+Index:
+    Background: Build
+    StandardLibrary: yes
+Diagnostics:
+    ClangTidy:
+        FastCheckFilter: Loose
+    UnusedIncludes: Strict
+    MissingIncludes: None
+Completion:
+    AllScopes: Yes
+InlayHints:
+    Enabled: Yes
+    ParameterNames: Yes
+    DeducedTypes: Yes
+    Designators: Yes
+    BlockEnd: Yes
+    TypeNameLimit: 0
+Hover:
+    ShowAKA: Yes

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,34 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  "format_on_save": "off",
+  "file_scan_exclusions": [
+    ".cache/"
+  ]
+  // The following LSP settings need to be copied into Zed settings.
+  // This uses the hermetic clangd from the llvm toolchain, but arguments
+  // may vary due to personal preference.
+  //
+  // https://github.com/zed-industries/zed/discussions/6629#discussioncomment-10493418
+  // https://github.com/zed-industries/zed/issues/4295#issuecomment-2287229162
+  // "lsp": {
+  //   "clangd": {
+  //     "binary": {
+  //       "path": "./external/llvm18_toolchain_llvm/bin/clangd",
+  //       "arguments": [
+  //        "--completion-parse=always",
+  //        "--parse-forwarding-functions",
+  //        "--use-dirty-headers",
+  //        "--include-ineligible-results",
+  //        "--header-insertion=never",
+  //        "--limit-references=0",
+  //        "--limit-results=0",
+  //        "--rename-file-limit=0",
+  //        "--enable-config"
+  //       ]
+  //     }
+  //   }
+  // }
+}

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -168,6 +168,35 @@ http_archive(
     url = "https://github.com/keith/rules_multirun/releases/download/0.9.0/rules_multirun.0.9.0.tar.gz",
 )
 
+BAZEL_COMPILE_COMMANDS_EXTRACTOR_COMMIT = "1e08f8e0507b6b6b1f4416a9a22cf5c28beaba93"
+
+http_archive(
+    name = "hedron_compile_commands",
+    integrity = "sha256-BEsUixEeF87mHYw6ru1CBp9zJUYDgjQK/KSRn4JlCUw=",
+    strip_prefix = "bazel-compile-commands-extractor-{commit}".format(
+        commit = BAZEL_COMPILE_COMMANDS_EXTRACTOR_COMMIT,
+    ),
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/{commit}.tar.gz".format(
+        commit = BAZEL_COMPILE_COMMANDS_EXTRACTOR_COMMIT,
+    ),
+)
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()
+
+load("@hedron_compile_commands//:workspace_setup_transitive.bzl", "hedron_compile_commands_setup_transitive")
+
+hedron_compile_commands_setup_transitive()
+
+load("@hedron_compile_commands//:workspace_setup_transitive_transitive.bzl", "hedron_compile_commands_setup_transitive_transitive")
+
+hedron_compile_commands_setup_transitive_transitive()
+
+load("@hedron_compile_commands//:workspace_setup_transitive_transitive_transitive.bzl", "hedron_compile_commands_setup_transitive_transitive_transitive")
+
+hedron_compile_commands_setup_transitive_transitive_transitive()
+
 SKYTEST_COMMIT = "bdac11a196d34006884b4e849245e17868a8fc0a"
 
 http_archive(


### PR DESCRIPTION
Set up `@hedron_compile_commands` to generate `compile_commands.json`
for use with clangd. Add configuration files for Zed and an example
`.clangd` file.

The LSP configuration needs to be defined in Zed settings (not Zed
project settings).

Change-Id: Id9e349ed503f497d8f3a2893852fb3c3472a9aa3