### PR TITLE
prevent multiple definitions from derived subtraction ops

### DIFF
--- a/rigid_geometric_algebra/BUILD.bazel
+++ b/rigid_geometric_algebra/BUILD.bazel
@@ -14,6 +14,7 @@ cc_library(
         "detail/derive_subtraction.hpp",
         "detail/derive_vector_space_operations.hpp",
         "detail/has_type.hpp",
+        "detail/is_defined.hpp",
         "detail/is_specialization_of.hpp",
         "detail/sorted_dimensions.hpp",
         "detail/structural_bitset.hpp",

--- a/rigid_geometric_algebra/detail/derive_subtraction.hpp
+++ b/rigid_geometric_algebra/detail/derive_subtraction.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "rigid_geometric_algebra/detail/is_defined.hpp"
+
 #include <functional>
 #include <type_traits>
-#include <utility>
 
 namespace rigid_geometric_algebra::detail {
 
@@ -10,8 +11,8 @@ namespace rigid_geometric_algebra::detail {
 /// @tparam D derived type
 ///
 /// Defines a subtraction operation for derived type D if
-/// +: D X T -> R
-/// is defined and D and T are not the same.
+/// +: T1 X T2 -> R
+/// is defined, where T1 or T2 is D.
 ///
 template <class D>
 struct derive_subtraction
@@ -23,8 +24,9 @@ struct derive_subtraction
   /// subtraction
   ///
   template <class T1, class T2>
-    requires is_derived_reference_v<T1> and (not is_derived_reference_v<T2>) and
-                 std::is_invocable_v<std::plus<>, T1, T2>
+    requires (is_derived_reference_v<T1> or is_derived_reference_v<T2>) and
+                 std::is_invocable_v<std::plus<>, T1, T2> and
+                 (not is_defined_v<op<derive_subtraction<void>, T1, T2>>)
   friend constexpr auto
   operator-(T1&& t1, T2&& t2) -> std::invoke_result_t<std::plus<>, T1, T2>
   {

--- a/rigid_geometric_algebra/detail/derive_vector_space_operations.hpp
+++ b/rigid_geometric_algebra/detail/derive_vector_space_operations.hpp
@@ -16,7 +16,7 @@ namespace rigid_geometric_algebra::detail {
 ///
 /// This type defines the following operations:
 /// -: D     -> D (negation)
-/// -: D x D -> D (subtraction)
+/// -: D x D -> D (subtraction) // TODO
 /// +: D x D -> D (addition)
 /// *: S x D -> D (scalar multiplication)
 ///
@@ -38,14 +38,15 @@ struct derive_vector_space_operations
     return {-(F{}(std::forward<T1>(t1)))...};
   }
 
-  /// subtraction
-  ///
-  template <class T1, class T2>
-    requires is_derived_reference_v<T1> and is_derived_reference_v<T2>
-  friend constexpr auto operator-(T1&& t1, T2&& t2) -> D
-  {
-    return {(F{}(std::forward<T1>(t1)) - F{}(std::forward<T2>(t2)))...};
-  }
+  // TODO define priorities for synthesized subtraction operations
+  //  /// subtraction
+  //  ///
+  //  template <class T1, class T2>
+  //    requires is_derived_reference_v<T1> and is_derived_reference_v<T2>
+  //  friend constexpr auto operator-(T1&& t1, T2&& t2) -> D
+  //  {
+  //    return {(F{}(std::forward<T1>(t1)) - F{}(std::forward<T2>(t2)))...};
+  //  }
 
   /// addition
   ///

--- a/rigid_geometric_algebra/detail/is_defined.hpp
+++ b/rigid_geometric_algebra/detail/is_defined.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "rigid_geometric_algebra/detail/type_list.hpp"
+
+#include <tuple>
+
+namespace rigid_geometric_algebra::detail {
+
+/// boolean state for a type
+/// @tparam Op type, usually denoting an operation
+///
+/// Flag used to store boolean state. The value associated with this flag is
+/// if the expression `is_defined(flag)` is well formed. On definition of
+/// `flag`, `is_defined(flag)` has deduced return type, but no definition to
+/// deduce a type, so a call is ill-formed.
+///
+template <class Op>
+struct flag
+{
+  friend constexpr auto is_defined(flag);
+};
+
+/// sets the boolean state for a flag
+/// @tparam Op type, usually denoting an operation
+///
+/// Helper used to set the state of `flag<Op>` to `true`. This type provides a
+/// definition for friend function `is_defined(flag<Op>)` in the enclosing
+/// namespace after it is instantiated for the first time. Afterwards, the
+/// expression `is_defined(flag<Op>)` is well formed.
+///
+template <class Op>
+struct set_defined
+{
+  friend constexpr auto is_defined(flag<Op>) {}
+};
+
+/// checks the state of a flag
+/// @tparam Op type, usually denoting an operation
+/// @tparam always_eval unique value used to force evaluation of
+///     `is_defined(flag<Op>)`
+///
+/// Checks the state of the flag. On the "first" call to this function,
+/// instantiates `set_defined<Op>` and returns `false`. Subsequent calls return
+/// `true`.
+///
+/// @see https://stackoverflow.com/a/58200261
+///
+template <class Op, auto always_eval = [] {}>
+consteval auto check_defined()
+{
+  if constexpr (requires { is_defined(flag<Op>{}); }) {
+    return true;
+  } else {
+    std::ignore = set_defined<Op>{};
+    return false;
+  }
+}
+
+/// checks if an operation is defined
+/// @tparam Op type, usually denoting an operation
+/// @tparam state deduced
+///
+/// Stateful boolean to check the state (true or false) associated with `Op`.
+/// On first use, the value is `false`. On subsequent uses, the value is `true`.
+///
+/// ~~~{.cpp}
+/// static_assert(not is_defined_v<op<std::minus<>, T, T>>);
+/// static_assert(is_defined_v<op<std::minus<>, T, T>>);
+/// ~~~
+///
+/// @see https://b.atch.se/posts/constexpr-counter/
+/// @see https://mc-deltat.github.io/articles/stateful-metaprogramming-cpp20
+/// @see
+/// https://stackoverflow.com/questions/44267673/is-stateful-metaprogramming-ill-formed-yet
+/// @see https://cplusplus.github.io/CWG/issues/2118.html
+///
+template <class Op, auto state = check_defined<Op>()>
+inline constexpr auto is_defined_v = state;
+
+/// helper used to identify an operation under test
+/// @tparam Ts types, typically a function object type followed by arguments
+/// types
+/// @relates is_defined_v
+///
+template <class... Ts>
+using op = type_list<Ts...>;
+
+}  // namespace rigid_geometric_algebra::detail

--- a/rigid_geometric_algebra/zero_constant.hpp
+++ b/rigid_geometric_algebra/zero_constant.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rigid_geometric_algebra/common_algebra_type.hpp"
+#include "rigid_geometric_algebra/detail/derive_subtraction.hpp"
 
 #include <type_traits>
 
@@ -13,7 +14,7 @@ namespace rigid_geometric_algebra {
 /// v ^ v for a vector v).
 ///
 template <class A>
-struct zero_constant
+struct zero_constant : detail::derive_subtraction<zero_constant<A>>
 {
   /// algebra this element belongs to
   ///

--- a/test/detail/BUILD.bazel
+++ b/test/detail/BUILD.bazel
@@ -11,3 +11,13 @@ cc_test(
         "@skytest",
     ],
 )
+
+cc_test(
+    name = "is_defined_test",
+    size = "small",
+    srcs = ["is_defined_test.cpp"],
+    deps = [
+        "//rigid_geometric_algebra",
+        "@skytest",
+    ],
+)

--- a/test/detail/is_defined_test.cpp
+++ b/test/detail/is_defined_test.cpp
@@ -1,0 +1,12 @@
+#include "rigid_geometric_algebra/detail/is_defined.hpp"
+
+#include <functional>
+
+auto main() -> int
+{
+  using ::rigid_geometric_algebra::detail::is_defined_v;
+  using ::rigid_geometric_algebra::detail::op;
+
+  static_assert(not is_defined_v<op<std::plus<>, int>>);
+  static_assert(is_defined_v<op<std::plus<>, int>>);
+}

--- a/test/zero_constant_test.cpp
+++ b/test/zero_constant_test.cpp
@@ -23,12 +23,19 @@ auto main() -> int
     return expect(eq(rga::zero, -rga::zero) and eq(rga::zero, -(-rga::zero)));
   };
 
-  "addition of zero and zero"_test = [] {
-    return expect(eq(rga::zero, rga::zero + rga::zero));
+  "addition/subtraction of zero and zero"_test = [] {
+    return expect(
+        eq(rga::zero, rga::zero + rga::zero) and
+        eq(rga::zero, rga::zero - rga::zero));
   };
 
   "addition of zero and blade"_test = [] {
     const auto v = rga::blade<1>{1};
     return expect(eq(v, rga::zero + v) and eq(v, v + rga::zero));
+  };
+
+  "subtraction of zero and blade"_test = [] {
+    const auto v = rga::blade<1>{1};
+    return expect(eq(-v, rga::zero - v) and eq(v, v - rga::zero));
   };
 }


### PR DESCRIPTION
`zero_constant` defines addition between `zero_constant` and `blade`:
  +: zero_constant X blade -> blade

Prior to this commit, inheriting from `derive_subtraction` with both
`zero_constant` and `blade` would result in multiple definitions of:

 -: zero_constant X blade -> blade

where one is defined by `derive_subtraction<zero_constant>` and the
other defined by `derive_subtraction<blade>`.

This commit uses stateful metaprogramming to disable overloads after the
first. As all overloads have identical definitions, it does not matter
which `derive_subtraction` overload is used.

https://mc-deltat.github.io/articles/stateful-metaprogramming-cpp20

Change-Id: I0b384b63a0e5338e749cdb6f195f3cdab8d70439