### PR TITLE
add symengine example

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -66,6 +66,9 @@ Checks: >
     # favor member init - reserving the non-init semantic as uninit (e.g. fundamental types, arrays),
     -readability-redundant-member-init,
 
+    # https://github.com/llvm/llvm-project/issues/91872,
+    -modernize-use-constraints,
+
 CheckOptions:
     - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
       value: true
@@ -75,6 +78,8 @@ CheckOptions:
       value : true
     - key: readability-implicit-bool-conversion.AllowPointerConditions
       value : true
+    - key: misc-include-cleaner.IgnoreHeaders
+      value: symengine/.*
 
 # only lint files coming from this project
 HeaderFilterRegex: '/rigid-geometric-algebra/'

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -209,3 +209,30 @@ http_archive(
         commit = SKYTEST_COMMIT,
     ),
 )
+
+# last commit before transition to bzlmod
+RULES_BOOST_COMMIT = "5d04542e52164931841d06d5a6b3fd2f43c436d0"
+
+http_archive(
+    name = "com_github_nelhage_rules_boost",
+    strip_prefix = "rules_boost-{commit}".format(
+        commit = RULES_BOOST_COMMIT,
+    ),
+    url = "https://github.com/nelhage/rules_boost/archive/{commit}.tar.gz".format(
+        commit = RULES_BOOST_COMMIT,
+    ),
+)
+
+load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
+
+boost_deps()
+
+http_archive(
+    name = "symengine",
+    build_file = "//third_party:symengine.BUILD.bazel",
+    integrity = "sha256-G1w7C8ap8YdjX5NYVknyShjpx/IWfOvNiF7eqvIR2VY=",
+    strip_prefix = "symengine-0.12.0",
+    urls = [
+        "https://github.com/symengine/symengine/archive/refs/tags/v0.12.0.tar.gz",
+    ],
+)

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -2,6 +2,19 @@ load("@rules_cc//cc:defs.bzl", "cc_test")
 
 package(default_visibility = ["//:__subpackages__"])
 
+cc_library(
+    name = "symengine",
+    hdrs = ["symengine/format.hpp"],
+    includes = ["."],
+    deps = ["@symengine"],
+)
+
+cc_binary(
+    name = "symengine-example",
+    srcs = ["symengine-example.cpp"],
+    deps = [":symengine"],
+)
+
 cc_test(
     name = "common_algebra_type_test",
     size = "small",

--- a/test/symengine-example.cpp
+++ b/test/symengine-example.cpp
@@ -1,0 +1,14 @@
+#include <format>
+#include <iostream>
+#include <symengine/expression.h>
+#include <symengine/format.hpp>
+
+auto main() -> int
+{
+  using SymEngine::Expression;
+
+  auto x = Expression{"x"};
+  auto ex = pow(x + sqrt(Expression{2}), 6);
+
+  std::cout << std::format("{}\n", ex);
+}

--- a/test/symengine/format.hpp
+++ b/test/symengine/format.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <format>
+#include <sstream>
+#include <string_view>
+#include <symengine/expression.h>
+
+namespace test::stx {
+
+// https://stackoverflow.com/questions/75738118/using-stdformat-with-types-that-have-operator
+template <typename Char>
+struct basic_ostream_formatter
+    : std::formatter<std::basic_string_view<Char>, Char>
+{
+  template <typename T, typename OutputIt>
+  constexpr auto
+  format(const T& value, std::basic_format_context<OutputIt, Char>& ctx) const
+      -> OutputIt
+  {
+    std::basic_stringstream<Char> ss;
+    ss << value;
+    return std::formatter<std::basic_string_view<Char>, Char>::format(
+        ss.view(), ctx);
+  }
+};
+
+}  // namespace test::stx
+
+template <class CharT>
+struct std::formatter<::SymEngine::Expression, CharT>
+    : ::test::stx::basic_ostream_formatter<CharT>
+{};

--- a/third_party/symengine.BUILD.bazel
+++ b/third_party/symengine.BUILD.bazel
@@ -1,0 +1,339 @@
+"""
+Build rules for symengine built with boost::multiprecision
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
+CONFIG_HEADER_CONTENT = """
+#ifndef SYMENGINE_CONFIG_HPP
+#define SYMENGINE_CONFIG_HPP
+
+#define SYMENGINE_MAJOR_VERSION {MAJOR_VERSION}
+#define SYMENGINE_MINOR_VERSION {MINOR_VERSION}
+#define SYMENGINE_PATCH_VERSION {PATCH_VERSION}
+#define SYMENGINE_VERSION "{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}"
+
+/* Define if you want to enable ASSERT testing in SymEngine */
+#define WITH_SYMENGINE_ASSERT
+
+/* Define if you want to enable SYMENGINE_RCP support in SymEngine */
+#define WITH_SYMENGINE_RCP
+
+/* Define if you want to enable SYMENGINE_THREAD_SAFE support in SymEngine */
+#define WITH_SYMENGINE_THREAD_SAFE
+
+/* Define if you want to enable BOOST support in SymEngine */
+#define HAVE_SYMENGINE_BOOST
+
+/* Define if you want to enable PTHREAD support in SymEngine */
+#define HAVE_SYMENGINE_PTHREAD
+
+/* Define if the C++ compiler supports default constructors */
+#define HAVE_DEFAULT_CONSTRUCTORS
+
+/* Define if the C++ compiler supports noexcept specifier */
+#define HAVE_SYMENGINE_NOEXCEPT
+
+/* Define if the C++ compiler supports std::is_constructible */
+#define HAVE_SYMENGINE_IS_CONSTRUCTIBLE
+
+/* Define if the C++ compiler supports std::unordered_map<>::reserve() */
+#define HAVE_SYMENGINE_RESERVE
+
+/* Define if the C++ compiler has std::to_string */
+#define HAVE_SYMENGINE_STD_TO_STRING
+
+#define SYMENGINE_GMPXX 0
+#define SYMENGINE_PIRANHA 1
+#define SYMENGINE_FLINT 2
+#define SYMENGINE_GMP 3
+#define SYMENGINE_BOOSTMP 4
+
+#define SYMENGINE_INTEGER_CLASS SYMENGINE_{INTEGER_CLASS}
+
+#define SYMENGINE_SIZEOF_LONG_DOUBLE sizeof(long double)
+
+#ifdef HAVE_SYMENGINE_NOEXCEPT
+#  define SYMENGINE_NOEXCEPT noexcept
+#else
+#  define SYMENGINE_NOEXCEPT
+#endif
+
+#include <symengine/symengine_export.h>
+
+#ifdef __CLING__
+#include "symengine/symengine_config_cling.h"
+#endif
+
+#endif
+""".format(
+    MAJOR_VERSION = 0,
+    MINOR_VERSION = 13,
+    PATCH_VERSION = 0,
+    INTEGER_CLASS = "BOOSTMP",
+)
+
+BOOSTMP_SRCS = [
+    "symengine/mp_boost.cpp",
+]
+
+write_file(
+    name = "symengine_config",
+    out = "symengine_config.h",
+    content = [CONFIG_HEADER_CONTENT],
+)
+
+EXPORT_HEADER_CONTENT = """
+#ifndef SYMENGINE_EXPORT_H
+#define SYMENGINE_EXPORT_H
+
+#define SYMENGINE_EXPORT
+
+#endif
+"""
+
+write_file(
+    name = "symengine_export",
+    out = "symengine_export.h",
+    content = [EXPORT_HEADER_CONTENT],
+)
+
+cc_library(
+    name = "generated",
+    hdrs = [
+        ":symengine_config",
+        ":symengine_export",
+    ],
+    include_prefix = "symengine",
+)
+
+cc_library(
+    name = "cereal",
+    hdrs = glob(["symengine/utilities/cereal/include/**/*"]),
+    includes = ["symengine/utilities/cereal/include"],
+)
+
+cc_library(
+    name = "fast_float",
+    hdrs = glob(["symengine/utilities/fast_float/include/**/*"]),
+    includes = ["symengine/utilities/fast_float/include"],
+)
+
+cc_library(
+    name = "symengine",
+    includes = ["."],
+    copts = [
+        "-Wno-conversion",
+        "-Wno-unused-parameter",
+        "-Wno-old-style-cast",
+        "-Wno-shadow",
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-but-set-variable",
+    ],
+    hdrs = [
+        "symengine/add.h",
+        "symengine/as_real_imag.cpp",
+        "symengine/basic.h",
+        "symengine/basic-inl.h",
+        "symengine/basic-methods.inc",
+        "symengine/complex_double.h",
+        "symengine/complex.h",
+        "symengine/complex_mpc.h",
+        "symengine/constants.h",
+        "symengine/cwrapper.h",
+        "symengine/derivative.h",
+        "symengine/dict.h",
+        "symengine/diophantine.h",
+        "symengine/eval_arb.h",
+        "symengine/eval_double.h",
+        "symengine/eval.h",
+        "symengine/eval_mpc.h",
+        "symengine/eval_mpfr.h",
+        "symengine/expression.h",
+        "symengine/fields.h",
+        "symengine/finitediff.h",
+        "symengine/flint_wrapper.h",
+        "symengine/functions.h",
+        "symengine/infinity.h",
+        "symengine/integer.h",
+        "symengine/lambda_double.h",
+        "symengine/llvm_double.h",
+        "symengine/logic.h",
+        "symengine/matrix.h",
+        "symengine/monomials.h",
+        "symengine/mp_class.h",
+        "symengine/mp_wrapper.h",
+        "symengine/mul.h",
+        "symengine/nan.h",
+        "symengine/ntheory.h",
+        "symengine/ntheory_funcs.h",
+        "symengine/number.h",
+        "symengine/parser.h",
+        "symengine/parser/parser.h",
+        "symengine/parser/parser.tab.hh",
+        "symengine/parser/tokenizer.h",
+        "symengine/parser/sbml/sbml_parser.h",
+        "symengine/parser/sbml/sbml_parser.tab.hh",
+        "symengine/parser/sbml/sbml_tokenizer.h",
+        "symengine/polys/basic_conversions.h",
+        "symengine/polys/cancel.h",
+        "symengine/polys/uexprpoly.h",
+        "symengine/polys/uintpoly_flint.h",
+        "symengine/polys/uintpoly.h",
+        "symengine/polys/uintpoly_piranha.h",
+        "symengine/polys/upolybase.h",
+        "symengine/polys/uratpoly.h",
+        "symengine/polys/usymenginepoly.h",
+        "symengine/polys/msymenginepoly.h",
+        "symengine/pow.h",
+        "symengine/prime_sieve.h",
+        "symengine/printers/codegen.h",
+        "symengine/printers/mathml.h",
+        "symengine/printers/sbml.h",
+        "symengine/printers/strprinter.h",
+        "symengine/printers/latex.h",
+        "symengine/printers/unicode.h",
+        "symengine/printers/stringbox.h",
+        "symengine/printers.h",
+        "symengine/rational.h",
+        "symengine/real_double.h",
+        "symengine/real_mpfr.h",
+        "symengine/rings.h",
+        "symengine/serialize-cereal.h",
+        "symengine/series_flint.h",
+        "symengine/series_generic.h",
+        "symengine/series.h",
+        "symengine/series_piranha.h",
+        "symengine/series_visitor.h",
+        "symengine/sets.h",
+        "symengine/solve.h",
+        "symengine/subs.h",
+        "symengine/symbol.h",
+        "symengine/symengine_assert.h",
+        "symengine/symengine_casts.h",
+        "symengine/symengine_exception.h",
+        "symengine/symengine_rcp.h",
+        "symengine/tribool.h",
+        "symengine/type_codes.inc",
+        "symengine/visitor.h",
+        "symengine/test_visitors.h",
+        "symengine/assumptions.h",
+        "symengine/refine.h",
+        "symengine/simplify.h",
+        "symengine/utilities/stream_fmt.h",
+        "symengine/tuple.h",
+        "symengine/matrix_expressions.h",
+        "symengine/matrices/matrix_expr.h",
+        "symengine/matrices/identity_matrix.h",
+        "symengine/matrices/matrix_symbol.h",
+        "symengine/matrices/zero_matrix.h",
+        "symengine/matrices/diagonal_matrix.h",
+        "symengine/matrices/immutable_dense_matrix.h",
+        "symengine/matrices/matrix_add.h",
+        "symengine/matrices/hadamard_product.h",
+        "symengine/matrices/matrix_mul.h",
+        "symengine/matrices/conjugate_matrix.h",
+        "symengine/matrices/size.h",
+        "symengine/matrices/transpose.h",
+        "symengine/matrices/trace.h",
+    ],
+    srcs = [
+        "symengine/add.cpp",
+        "symengine/basic.cpp",
+        "symengine/complex.cpp",
+        "symengine/complex_double.cpp",
+        "symengine/constants.cpp",
+        "symengine/cse.cpp",
+        "symengine/cwrapper.cpp",
+        "symengine/dense_matrix.cpp",
+        "symengine/derivative.cpp",
+        "symengine/dict.cpp",
+        "symengine/diophantine.cpp",
+        "symengine/eval.cpp",
+        "symengine/eval_double.cpp",
+        "symengine/expand.cpp",
+        "symengine/expression.cpp",
+        "symengine/fields.cpp",
+        "symengine/finitediff.cpp",
+        "symengine/functions.cpp",
+        "symengine/infinity.cpp",
+        "symengine/integer.cpp",
+        "symengine/logic.cpp",
+        "symengine/matrix.cpp",
+        "symengine/monomials.cpp",
+        "symengine/mul.cpp",
+        "symengine/nan.cpp",
+        "symengine/ntheory.cpp",
+        "symengine/ntheory_funcs.cpp",
+        "symengine/number.cpp",
+        "symengine/numer_denom.cpp",
+        "symengine/parser/parser_old.cpp",
+        "symengine/parser/parser.tab.cc",
+        "symengine/parser/parser.cpp",
+        "symengine/parser/tokenizer.cpp",
+        "symengine/parser/sbml/sbml_parser.tab.cc",
+        "symengine/parser/sbml/sbml_parser.cpp",
+        "symengine/parser/sbml/sbml_tokenizer.cpp",
+        "symengine/polys/basic_conversions.cpp",
+        "symengine/polys/msymenginepoly.cpp",
+        "symengine/polys/uexprpoly.cpp",
+        "symengine/polys/uintpoly.cpp",
+        "symengine/polys/uratpoly.cpp",
+        "symengine/pow.cpp",
+        "symengine/prime_sieve.cpp",
+        "symengine/printers/codegen.cpp",
+        "symengine/printers/mathml.cpp",
+        "symengine/printers/sbml.cpp",
+        "symengine/printers/strprinter.cpp",
+        "symengine/printers/latex.cpp",
+        "symengine/printers/unicode.cpp",
+        "symengine/printers/stringbox.cpp",
+        "symengine/rational.cpp",
+        "symengine/real_double.cpp",
+        "symengine/rewrite.cpp",
+        "symengine/rings.cpp",
+        "symengine/series.cpp",
+        "symengine/series_generic.cpp",
+        "symengine/sets.cpp",
+        "symengine/set_funcs.cpp",
+        "symengine/solve.cpp",
+        "symengine/sparse_matrix.cpp",
+        "symengine/symbol.cpp",
+        "symengine/symengine_rcp.cpp",
+        "symengine/visitor.cpp",
+        "symengine/test_visitors.cpp",
+        "symengine/assumptions.cpp",
+        "symengine/refine.cpp",
+        "symengine/simplify.cpp",
+        "symengine/tuple.cpp",
+        "symengine/matrices/identity_matrix.cpp",
+        "symengine/matrices/matrix_symbol.cpp",
+        "symengine/matrices/zero_matrix.cpp",
+        "symengine/matrices/diagonal_matrix.cpp",
+        "symengine/matrices/immutable_dense_matrix.cpp",
+        "symengine/matrices/matrix_add.cpp",
+        "symengine/matrices/hadamard_product.cpp",
+        "symengine/matrices/matrix_mul.cpp",
+        "symengine/matrices/conjugate_matrix.cpp",
+        "symengine/matrices/transpose.cpp",
+        "symengine/matrices/trace.cpp",
+        "symengine/matrices/size.cpp",
+        "symengine/matrices/is_zero.cpp",
+        "symengine/matrices/is_real.cpp",
+        "symengine/matrices/is_symmetric.cpp",
+        "symengine/matrices/is_square.cpp",
+        "symengine/matrices/is_diagonal.cpp",
+        "symengine/matrices/is_lower.cpp",
+        "symengine/matrices/is_upper.cpp",
+        "symengine/matrices/is_toeplitz.cpp",
+    ] + BOOSTMP_SRCS,
+    deps = [
+        "@boost//:multiprecision",
+        "@boost//:random",
+        ":generated",
+        ":cereal",
+        ":fast_float",
+    ],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This commit also disables ClangTidy check `modernize-use-constraints`
due to a segfault when analyzing symengine.

Change-Id: I82ed3651ff9417ae7dcbb368db96a5619b2ceb35