### PR TITLE
define wedge operator for `point`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -69,6 +69,9 @@ Checks: >
     # https://github.com/llvm/llvm-project/issues/91872,
     -modernize-use-constraints,
 
+    # false positives in symengine (check workflow runs tests with asan),
+    -clang-analyzer-core.uninitialized.Assign,
+
 CheckOptions:
     - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
       value: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,9 +22,24 @@ jobs:
         os:
           - 'ubuntu-latest'
           - 'macos-latest'
+        feature:
+          - ''
+        include:
+          - compilation_mode: 'fastbuild'
+            toolchain: 'clang18'
+            os: 'ubuntu-latest'
+            feature: 'asan'
+          - compilation_mode: 'fastbuild'
+            toolchain: 'clang18'
+            os: 'ubuntu-latest'
+            feature: 'tsan'
+          - compilation_mode: 'fastbuild'
+            toolchain: 'clang18'
+            os: 'ubuntu-latest'
+            feature: 'ubsan'
     runs-on: ${{ matrix.os }}
     env:
-      PROFILE: profile-${{ matrix.os }}-${{ matrix.compilation_mode }}-${{ matrix.toolchain }}.gz
+      PROFILE: profile-${{ matrix.os }}-${{ matrix.compilation_mode }}-${{ matrix.toolchain }}-${{ matrix.feature }}.gz
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-env-setup
@@ -36,6 +51,7 @@ jobs:
           --profile=$PROFILE \
           --compilation_mode=${{ matrix.compilation_mode }} \
           --extra_toolchains=//tools:${{ matrix.toolchain }}_toolchain \
+          --features=${{ matrix.feature }} \
           //...
 
         bazel analyze-profile $PROFILE

--- a/rigid_geometric_algebra/point.hpp
+++ b/rigid_geometric_algebra/point.hpp
@@ -81,6 +81,21 @@ public:
     return std::forward_like<Self>(refs[i].get());
   }
 
+  /// wedge product
+  ///
+  /// @{
+
+  template <class P>
+    requires std::is_same_v<P, point>
+  friend constexpr auto operator^(const P& p, const P& q)
+      // TODO return line
+      -> decltype(p.multivector() ^ q.multivector())
+  {
+    return p.multivector() ^ q.multivector();
+  }
+
+  /// @}
+
   /// equality comparison
   ///
   /// @{


### PR DESCRIPTION
This commit also disables ClangTidy check
`clang-analyzer-core.uninitialized.Assign` due to false positives in
`symengine`'s reference-counted pointer implementation.

To detect uninitialized memory errors that may arise, this commit
enables tests with sanitizers in the check workflow.

Change-Id: I7652ee79feae757e147f82d1443be84f4729ebe9