### PR TITLE
allow option and target specification for `//tools:lint`

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -79,18 +79,27 @@ genrule(
     cmd = """
 echo "#!/bin/bash" > $@
 echo "cd \\$$BUILD_WORKSPACE_DIRECTORY" >> $@
-echo "exec bazel build \\$$@ -- //..." >> $@
-""",
+echo "exec bazel build {options} \\$${{@:-//...}}" >> $@
+""".format(
+        options = " ".join([
+            "--extra_toolchains=//tools:clang18_toolchain",
+            "--aspects=@rules_clang_tidy//:aspects.bzl%check",
+            "--output_groups=report",
+            "--keep_going",
+            "--verbose_failures",
+        ]),
+    ),
 )
 
+# lint all targets with default options
+#  bazel run //tools:lint
+#
+# lint with a single check on a single target
+#   bazel run //tools:lint -- \
+#     --@rules_clang_tidy//:extra-options=--checks='-*,clang-analyzer-core.uninitialized.Assign' \
+#     //test:point_test
+#
 sh_binary(
     name = "lint",
     srcs = ["clang-tidy.sh"],
-    args = [
-        "--extra_toolchains=//tools:clang18_toolchain",
-        "--aspects=@rules_clang_tidy//:aspects.bzl%check",
-        "--output_groups=report",
-        "--keep_going",
-        "--verbose_failures",
-    ],
 )


### PR DESCRIPTION
Allow arguments to be specified for the `@rules_clang_tidy` aspect, as
well as target specification.

If no arguments are passed to `//tools:lint`, linting applies to all
targets in the workspace using a wildcard label. If any argument is
passed, even a non-label, the lint targets must be explicitly
specified.

Change-Id: Id0f236dd9929deccd495d674121daf64f1223859