### PR TITLE
fix unintended conversions to `blade`

### DIFF
--- a/rigid_geometric_algebra/blade.hpp
+++ b/rigid_geometric_algebra/blade.hpp
@@ -109,13 +109,6 @@ public:
   ///
   blade() = default;
 
-  /// coefficient constructor
-  /// @param value coefficient value
-  ///
-  /// constructs a blade with coefficient specified by value
-  ///
-  constexpr blade(value_type value) : coefficient{std::move(value)} {}
-
   /// initializer list constructor
   /// @param il initializer list of values
   ///
@@ -137,7 +130,8 @@ public:
   ///
   template <class T>
     requires std::constructible_from<value_type, T>
-  constexpr blade(T&& value) : coefficient{std::forward<T>(value)}
+  constexpr explicit(grade != 0) blade(T&& value)
+      : coefficient{std::forward<T>(value)}
   {}
 
   /// obtain the blade with indices in canonical form
@@ -155,7 +149,7 @@ public:
         std::identity,
         std::negate<>>;
 
-    return {maybe_negate{}(std::forward<Self>(self).coefficient)};
+    return canonical_type{maybe_negate{}(std::forward<Self>(self).coefficient)};
   }
 
   /// addition

--- a/rigid_geometric_algebra/detail/derive_vector_space_operations.hpp
+++ b/rigid_geometric_algebra/detail/derive_vector_space_operations.hpp
@@ -50,7 +50,7 @@ public:
     requires is_derived_reference_v<T1>
   friend constexpr auto operator-(T1&& t1) -> D
   {
-    return {-(F{}(std::forward<T1>(t1)))...};
+    return D{-(F{}(std::forward<T1>(t1)))...};
   }
 
   /// subtraction
@@ -74,7 +74,7 @@ public:
     requires is_derived_reference_v<T1> and is_derived_reference_v<T2>
   friend constexpr auto operator+(T1&& t1, T2&& t2) -> D
   {
-    return {(F{}(std::forward<T1>(t1)) + F{}(std::forward<T2>(t2)))...};
+    return D{(F{}(std::forward<T1>(t1)) + F{}(std::forward<T2>(t2)))...};
   }
 
   /// scalar multiplication
@@ -89,7 +89,7 @@ public:
                ...))
   friend constexpr auto operator*(const S& s, T2&& t2) -> D
   {
-    return {(s * F{}(std::forward<T2>(t2)))...};
+    return D{(s * F{}(std::forward<T2>(t2)))...};
   }
 
   /// equality comparison

--- a/test/blade_test.cpp
+++ b/test/blade_test.cpp
@@ -2,13 +2,16 @@
 #include "skytest/skytest.hpp"
 
 #include <format>
+#include <functional>
 
 auto main() -> int
 {
   using namespace skytest::literals;
   using ::skytest::eq;
   using ::skytest::expect;
+  using ::skytest::function;
   using ::skytest::ne;
+  using ::skytest::pred;
 
   using G2 = ::rigid_geometric_algebra::algebra<double, 2>;
 
@@ -29,6 +32,21 @@ auto main() -> int
     const auto c = G2::blade<>{1};
 
     return expect(eq(a, b) and ne(a, c) and ne(b, c));
+  };
+
+  "comparable with field type (if scalar)"_test = [] {
+    return expect(eq(1., G2::blade<>{1}));
+  };
+
+  "not comparable with field type (if non-scalar)"_test = [] {
+    const auto comparable = pred(
+        function<"comparable">, []<class T1, class T2>(const T1&, const T2&) {
+          return std::is_invocable_v<std::equal_to<>, T1, T2>;
+        });
+
+    return expect(
+        not comparable(1., G2::blade<0>{}) and
+        not comparable(1., G2::blade<0, 1, 2>{}));
   };
 
   "grade"_test = [] {


### PR DESCRIPTION
Define the `blade` converting constructor as conditionally explicit. An
implicit conversion is only allowed for blade of grade 0, as those
represent scalars.

Change-Id: I6341e7da31a7df85f8e748badc6709adb64df981