### PR TITLE
generate coverage report with `//tools:coverage`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,8 +27,9 @@ build:remote --nolegacy_important_outputs
 test --test_verbose_timeout_warnings
 
 # https://github.com/bazelbuild/bazel/issues/14970#issuecomment-1894565761
-coverage --instrumentation_filter=//rigid_geometric_algebra
+coverage --copt=-ffile-compilation-dir=.
 coverage --combined_report=lcov
 coverage --experimental_generate_llvm_lcov
+coverage --instrumentation_filter=//rigid_geometric_algebra
 
 try-import %workspace%/user.bazelrc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,8 +70,8 @@ jobs:
       with:
         buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - run: |
-        bazel coverage --profile=$PROFILE \
-          //...
+        bazel run --profile=$PROFILE \
+          //tools:coverage
 
         bazel analyze-profile $PROFILE
     - uses: actions/upload-artifact@v4

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -327,3 +327,19 @@ native_binary(
         release = RUFF_RELEASE,
     ),
 )
+
+http_archive(
+    name = "lcov",
+    build_file_content = """\
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
+    name = "genhtml",
+    src = "bin/genhtml",
+    visibility = ["//visibility:public"],
+)
+    """,
+    integrity = "sha256-mHAxrVUoyKdG1LUrOAvBv/5BLeHyucK6UiSZVmjjJAs=",
+    strip_prefix = "lcov-1.16",
+    url = "https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16.tar.gz",
+)

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -79,7 +79,7 @@ buildifier(
 
 genrule(
     name = "gen-clang-format",
-    outs = ["clang-format.sh"],
+    outs = ["clang-format.bash"],
     cmd = """
 echo "#!/bin/bash" > $@
 echo "cd \\$$BUILD_WORKSPACE_DIRECTORY" >> $@
@@ -89,7 +89,7 @@ echo "exec bazel build \\$$@ //..." >> $@
 
 sh_binary(
     name = "clang-format.check",
-    srcs = ["clang-format.sh"],
+    srcs = ["clang-format.bash"],
     args = [
         "--aspects=@bazel_clang_format//:defs.bzl%check_aspect",
         "--output_groups=report",
@@ -99,7 +99,7 @@ sh_binary(
 
 sh_binary(
     name = "clang-format",
-    srcs = ["clang-format.sh"],
+    srcs = ["clang-format.bash"],
     args = [
         "--aspects=@bazel_clang_format//:defs.bzl%fix_aspect",
         "--output_groups=report",
@@ -128,7 +128,7 @@ multirun(
 
 genrule(
     name = "gen-clang-tidy",
-    outs = ["clang-tidy.sh"],
+    outs = ["clang-tidy.bash"],
     cmd = """
 echo "#!/bin/bash" > $@
 echo "cd \\$$BUILD_WORKSPACE_DIRECTORY" >> $@
@@ -154,7 +154,7 @@ echo "exec bazel build {options} \\$${{@:-//...}}" >> $@
 #
 sh_binary(
     name = "clang-tidy",
-    srcs = ["clang-tidy.sh"],
+    srcs = ["clang-tidy.bash"],
 )
 
 multirun(
@@ -163,4 +163,42 @@ multirun(
         ":clang-tidy",
         ":ruff.lint",
     ],
+)
+
+genrule(
+    name = "gen-coverage",
+    srcs = ["@lcov//:genhtml"],
+    outs = ["coverage.bash"],
+    cmd = """
+echo "#!/bin/bash" > $@
+echo "set -euo pipefail" >> $@
+echo "" >> $@
+echo "cd \\$$BUILD_WORKSPACE_DIRECTORY" >> $@
+echo "COVERAGE_DIR=\\"\\$$(bazel info output_path)/_coverage\\"" >> $@
+echo "bazel coverage \\$${{@:-//...}}" >> $@
+echo "$(execpath @lcov//:genhtml) {options} {report}" >> $@
+echo "" >> $@
+echo "echo wrote coverage report to" >> $@
+echo "echo file://\\$${{COVERAGE_DIR}}/html/index.html" >> $@
+""".format(
+        options = " ".join([
+            "--output-directory \\$${COVERAGE_DIR}/html",
+            "--show-details",
+            "--function-coverage",
+            "--branch-coverage",
+            "--title rigid-geometric-algebra",
+            "--highlight",
+            "--legend",
+            "--missed",
+            "--demangle-cpp",
+            "--dark-mode",
+        ]),
+        report = "\\$${COVERAGE_DIR}/_coverage_report.dat",
+    ),
+)
+
+sh_binary(
+    name = "coverage",
+    srcs = [":coverage.bash"],
+    data = ["@lcov//:genhtml"],
 )


### PR DESCRIPTION
Use `genhtml` to generate the coverage report locally. This may differ
from the one generated by codecov.

Update check workflow to use the coverage data produced
`//tools:coverage`.

Change-Id: I1c76edf442167dd978aa8568a607033c8f4f65d3