### PR TITLE
update llvm toolchain to 19.1.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,11 +7,11 @@ build --incompatible_strict_action_env
 build --ui_actions_shown=20
 build --progress_in_terminal_title
 
-build --@bazel_clang_format//:binary=@llvm18_toolchain//:clang-format
+build --@bazel_clang_format//:binary=@llvm19_toolchain//:clang-format
 build --@bazel_clang_format//:config=//:format-config
 
-build --@rules_clang_tidy//:clang-tidy=@llvm18_toolchain//:clang-tidy
-build --@rules_clang_tidy//:clang-apply-replacements=@llvm18_toolchain//:clang-apply-replacements
+build --@rules_clang_tidy//:clang-tidy=@llvm19_toolchain//:clang-tidy
+build --@rules_clang_tidy//:clang-apply-replacements=@llvm19_toolchain//:clang-apply-replacements
 build --@rules_clang_tidy//:config=//:tidy-config
 
 build:remote --remote_cache=grpcs://oliverlee.buildbuddy.io

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,19 +22,11 @@ Checks: >
     # allow unused variables to be unnamed,
     -readability-named-parameter,
 
-    # C-arrays necessary as function args,
-    -modernize-avoid-c-arrays,
-
     # use iterators as abstractions, not pointers,
     -readability-qualified-auto,
 
     # it's okay for exceptions to escape main,
     -bugprone-exception-escape,
-
-    # false positive with spaceship operator,
-    # https://reviews.llvm.org/D95714?id=320393,
-    # NOTE: still false positive with LLVM 17.0.2,
-    -modernize-use-nullptr,
 
     # disable common aliases,
     -cppcoreguidelines-avoid-c-arrays,
@@ -44,9 +36,7 @@ Checks: >
     -cppcoreguidelines-non-private-member-variables-in-classes,
 
     # disable EXTREMELY SLOW checks,
-    -bugprone-reserved-identifier,
     -readability-identifier-naming,
-    -misc-confusable-identifiers,
 
     # there are magic numbers in tests,
     -readability-magic-numbers,
@@ -54,23 +44,11 @@ Checks: >
     # hinnant style special member functions,
     -cppcoreguidelines-special-member-functions,
 
-    # this library defines a DSL,
-    -misc-unconventional-assign-operator,
-
-    # false positives,
-    -readability-simplify-boolean-expr,
-
     # false positives with overloaded operators (e.g. `^`),
     -misc-redundant-expression,
 
     # favor member init - reserving the non-init semantic as uninit (e.g. fundamental types, arrays),
     -readability-redundant-member-init,
-
-    # https://github.com/llvm/llvm-project/issues/91872,
-    -modernize-use-constraints,
-
-    # false positives in symengine (check workflow runs tests with asan),
-    -clang-analyzer-core.uninitialized.Assign,
 
     # https://www.foonathan.net/2023/08/static-constexpr-integral_constant/,
     -readability-static-accessed-through-instance,

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
           - 'opt'
         toolchain:
           #- 'gcc12' # GCC12 has missing support for C++23
-          - 'clang18'
+          - 'clang19'
         os:
           - 'ubuntu-latest'
           - 'macos-latest'
@@ -26,15 +26,15 @@ jobs:
           - ''
         include:
           - compilation_mode: 'fastbuild'
-            toolchain: 'clang18'
+            toolchain: 'clang19'
             os: 'ubuntu-latest'
             feature: 'asan'
           - compilation_mode: 'fastbuild'
-            toolchain: 'clang18'
+            toolchain: 'clang19'
             os: 'ubuntu-latest'
             feature: 'tsan'
           - compilation_mode: 'fastbuild'
-            toolchain: 'clang18'
+            toolchain: 'clang19'
             os: 'ubuntu-latest'
             feature: 'ubsan'
     runs-on: ${{ matrix.os }}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -37,7 +37,7 @@
   "lsp": {
     "clangd": {
       "binary": {
-        "path": "./external/llvm18_toolchain_llvm/bin/clangd",
+        "path": "./external/llvm_toolchain_llvm/bin/clangd",
         "arguments": [
           "--function-arg-placeholders=0",
           "--completion-parse=always",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -31,15 +31,15 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
 )
 
-TOOLCHAINS_LLVM_COMMIT = "b1a6c86b42ee2373574d0e6862d9d9d5405c3146"
+TOOLCHAINS_LLVM_COMMIT = "4ab573b1b87a57791ef2f9ccee71cbad80a2abb9"
 
 http_archive(
     name = "toolchains_llvm",
-    integrity = "sha256-hdEfwQEvZaPD/gp6A9iDSIxxKOBYrn+ttFYjAHfFby8=",
-    strip_prefix = "bazel-toolchain-{commit}".format(
+    integrity = "sha256-sCbaVUYAogO0jJ8N8CY4DYNdJLVLV0Z3TiPMKl81f44=",
+    strip_prefix = "toolchains_llvm-{commit}".format(
         commit = TOOLCHAINS_LLVM_COMMIT,
     ),
-    url = "https://github.com/oliverlee/bazel-toolchain/archive/{commit}.tar.gz".format(
+    url = "https://github.com/bazel-contrib/toolchains_llvm/archive/{commit}.tar.gz".format(
         commit = TOOLCHAINS_LLVM_COMMIT,
     ),
 )
@@ -52,7 +52,7 @@ load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 
 # https://github.com/bazel-contrib/toolchains_llvm/blob/192cf04bbb11b29a8ca6756e269d27a840bfa14b/toolchain/internal/repo.bzl
 llvm_toolchain(
-    name = "llvm18_toolchain",
+    name = "llvm19_toolchain",
     cxx_flags = {
         "": [
             "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
@@ -67,11 +67,11 @@ llvm_toolchain(
     link_libs = {
         "": ["-fsanitize-link-c++-runtime"],
     },
-    llvm_version = "18.1.8",
+    llvm_version = "19.1.0",
 )
 
 # register llvm first, it has better error messages
-load("@llvm18_toolchain//:toolchains.bzl", "llvm_register_toolchains")
+load("@llvm19_toolchain//:toolchains.bzl", "llvm_register_toolchains")
 
 llvm_register_toolchains()
 

--- a/rigid_geometric_algebra/blade.hpp
+++ b/rigid_geometric_algebra/blade.hpp
@@ -162,7 +162,7 @@ public:
   ///
   template <detail::decays_to<blade> B1, class B2>
     requires (not detail::decays_to<B2, blade>) and
-                 std::is_same_v<canonical_type, canonical_type_t<B2>>
+             std::is_same_v<canonical_type, canonical_type_t<B2>>
   friend constexpr auto operator+(B1&& lhs, B2&& rhs) -> canonical_type
   {
     return std::forward<B1>(lhs).canonical() +

--- a/rigid_geometric_algebra/blade_complement_type.hpp
+++ b/rigid_geometric_algebra/blade_complement_type.hpp
@@ -15,8 +15,7 @@ struct blade_complement_type_
 {};
 
 template <
-    template <class, std::size_t...>
-    class blade_,
+    template <class, std::size_t...> class blade_,
     class A,
     std::size_t... Is>
 struct blade_complement_type_<true, blade_<A, Is...>>

--- a/rigid_geometric_algebra/blade_ordering.hpp
+++ b/rigid_geometric_algebra/blade_ordering.hpp
@@ -41,8 +41,9 @@ struct blade_ordering
 
   /// equality operator
   ///
-  friend constexpr auto operator==(
-      const blade_ordering& lhs, const blade_ordering& rhs) noexcept -> bool
+  friend constexpr auto
+  operator==(const blade_ordering& lhs, const blade_ordering& rhs) noexcept
+      -> bool
   {
     return lhs.mask == rhs.mask;
   }

--- a/rigid_geometric_algebra/complement.hpp
+++ b/rigid_geometric_algebra/complement.hpp
@@ -46,8 +46,7 @@ class blade_complement_negates_fn
   {};
 
   template <
-      template <class, std::size_t...>
-      class blade_,
+      template <class, std::size_t...> class blade_,
       class A,
       std::size_t... Is,
       std::size_t... Js>

--- a/rigid_geometric_algebra/detail/contract.hpp
+++ b/rigid_geometric_algebra/detail/contract.hpp
@@ -112,9 +112,9 @@ struct contract_violation_handler : logging_violation_handler<Args...>
 
 template <class Handler>
   requires std::is_invocable_v<
-               const Handler&,
-               precondition_contract,
-               const std::source_location&>
+      const Handler&,
+      precondition_contract,
+      const std::source_location&>
 constexpr auto precondition(
     const std::convertible_to<bool> auto& cond,
     const Handler& violation_handler,
@@ -148,9 +148,9 @@ constexpr auto precondition(
 
 template <class Handler>
   requires std::is_invocable_v<
-               const Handler&,
-               postcondition_contract,
-               const std::source_location&>
+      const Handler&,
+      postcondition_contract,
+      const std::source_location&>
 constexpr auto postcondition(
     const std::convertible_to<bool> auto& cond,
     const Handler& violation_handler,

--- a/rigid_geometric_algebra/detail/derive_multivector_overload.hpp
+++ b/rigid_geometric_algebra/detail/derive_multivector_overload.hpp
@@ -28,8 +28,7 @@ class derive_multivector_overload
 {
   template <
       class Self = D,
-      template <class...>
-      class list,
+      template <class...> class list,
       class... Bs,
       class V>
   static constexpr auto impl(list<Bs...>, V&& v)
@@ -63,19 +62,19 @@ class derive_multivector_overload
 
   template <
       class Self = D,
-      template <class...>
-      class list,
+      template <class...> class list,
       class... Pairs,
       class V1,
       class V2>
     requires (sizeof...(Pairs) != 0)
-  static constexpr auto impl2(list<Pairs...>, V1&& v1, V2&& v2) ->
-      typename sorted_canonical_blades_t<std::invoke_result_t<
+  static constexpr auto
+  impl2(list<Pairs...>, V1&& v1, V2&& v2) -> typename sorted_canonical_blades_t<
+      std::invoke_result_t<
           Self,
           detail::copy_ref_qual_t<V1&&, typename Pairs::first_type>,
           detail::copy_ref_qual_t<V2&&, typename Pairs::second_type>>...>::
-          template insert_into_t<::rigid_geometric_algebra::multivector<
-              common_algebra_type_t<V1, V2>>>
+      template insert_into_t<
+          ::rigid_geometric_algebra::multivector<common_algebra_type_t<V1, V2>>>
   {
     return blade_sum(Self::operator()(
         get<typename Pairs::first_type>(std::forward<V1>(v1)),
@@ -83,11 +82,10 @@ class derive_multivector_overload
   }
 
   template <class Self = D, class V1, class V2>
-  static constexpr auto impl(V1&& v1, V2&& v2)
-      -> decltype(impl2(
-          blade_list_product_t<Self, V1, V2>{},
-          std::forward<V1>(v1),
-          std::forward<V2>(v2)))
+  static constexpr auto impl(V1&& v1, V2&& v2) -> decltype(impl2(
+      blade_list_product_t<Self, V1, V2>{},
+      std::forward<V1>(v1),
+      std::forward<V2>(v2)))
   {
     return impl2(
         blade_list_product_t<Self, V1, V2>{},
@@ -97,10 +95,8 @@ class derive_multivector_overload
 
 public:
   template <detail::multivector V>
-  static constexpr auto operator()(V&& v)
-      -> decltype(impl(
-          typename std::remove_cvref_t<V>::blade_list_type{},
-          std::forward<V>(v)))
+  static constexpr auto operator()(V&& v) -> decltype(impl(
+      typename std::remove_cvref_t<V>::blade_list_type{}, std::forward<V>(v)))
   {
     return impl(
         typename std::remove_cvref_t<V>::blade_list_type{}, std::forward<V>(v));
@@ -109,11 +105,10 @@ public:
       detail::multivector_promotable V1,
       detail::multivector_promotable V2>
     requires (not(detail::blade<V1> and detail::blade<V2>)) and
-                 has_common_algebra_type_v<V1, V2>
-  static constexpr auto operator()(V1&& v1, V2&& v2)
-      -> decltype(impl(
-          to_multivector(std::forward<V1>(v1)),
-          to_multivector(std::forward<V2>(v2))))
+             has_common_algebra_type_v<V1, V2>
+  static constexpr auto operator()(V1&& v1, V2&& v2) -> decltype(impl(
+      to_multivector(std::forward<V1>(v1)),
+      to_multivector(std::forward<V2>(v2))))
   {
     return impl(
         to_multivector(std::forward<V1>(v1)),

--- a/rigid_geometric_algebra/detail/derive_subtraction.hpp
+++ b/rigid_geometric_algebra/detail/derive_subtraction.hpp
@@ -38,11 +38,11 @@ public:
   ///
   template <class T1, class T2>
     requires (detail::decays_to<T1, D> or detail::decays_to<T2, D>) and
-                 std::is_invocable_v<std::plus<>, T1, T2> and
-                 define_prioritized_overload_v<
-                     priority_for<std::minus<>, derive_subtraction<>>,
-                     overload<std::minus<>, T1, T2>,
-                     default_subtraction>
+             std::is_invocable_v<std::plus<>, T1, T2> and
+             define_prioritized_overload_v<
+                 priority_for<std::minus<>, derive_subtraction<>>,
+                 overload<std::minus<>, T1, T2>,
+                 default_subtraction>
   friend constexpr auto
   operator-(T1&& t1, T2&& t2) -> std::invoke_result_t<std::plus<>, T1, T2>
   {

--- a/rigid_geometric_algebra/detail/derive_vector_space_operations.hpp
+++ b/rigid_geometric_algebra/detail/derive_vector_space_operations.hpp
@@ -53,9 +53,9 @@ public:
   ///
   template <detail::decays_to<D> T1, detail::decays_to<D> T2>
     requires define_prioritized_overload_v<
-                 priority_for<std::minus<>, derive_vector_space_operations<>>,
-                 overload<std::minus<>, T1, T2>,
-                 minus_impl>
+        priority_for<std::minus<>, derive_vector_space_operations<>>,
+        overload<std::minus<>, T1, T2>,
+        minus_impl>
   friend constexpr auto operator-(T1&& t1, T2&& t2) -> D
   {
     return invoke_prioritized_overload<std::minus<>>(
@@ -73,12 +73,13 @@ public:
   /// scalar multiplication
   ///
   template <class S, detail::decays_to<D> T2>
-    requires ((std::is_invocable_r_v<
-                   std::remove_cvref_t<std::invoke_result_t<F, T2>>,
-                   std::multiplies<>,
-                   S,
-                   std::invoke_result_t<F, T2>> and
-               ...))
+    requires ((
+        std::is_invocable_r_v<
+            std::remove_cvref_t<std::invoke_result_t<F, T2>>,
+            std::multiplies<>,
+            S,
+            std::invoke_result_t<F, T2>> and
+        ...))
   friend constexpr auto operator*(const S& s, T2&& t2) -> D
   {
     return D{(s * F{}(std::forward<T2>(t2)))...};

--- a/rigid_geometric_algebra/detail/derive_zero_constant_overload.hpp
+++ b/rigid_geometric_algebra/detail/derive_zero_constant_overload.hpp
@@ -22,8 +22,8 @@ public:
   }
   template <class T1, class T2>
     requires has_common_algebra_type_v<T1, T2> and
-                 (detail::decays_to<T1, zero_constant<algebra_type_t<T1>>> or
-                  detail::decays_to<T2, zero_constant<algebra_type_t<T2>>>)
+             (detail::decays_to<T1, zero_constant<algebra_type_t<T1>>> or
+              detail::decays_to<T2, zero_constant<algebra_type_t<T2>>>)
   static constexpr auto operator()(const T1&, const T2&)
       -> zero_constant<common_algebra_type_t<T1, T2>>
   {

--- a/rigid_geometric_algebra/detail/rebind_args_into.hpp
+++ b/rigid_geometric_algebra/detail/rebind_args_into.hpp
@@ -11,11 +11,9 @@ struct rebind_args_into
 {};
 
 template <
-    template <class...>
-    class from,
+    template <class...> class from,
     class... Ts,
-    template <class...>
-    class to>
+    template <class...> class to>
 struct rebind_args_into<from<Ts...>, to>
 {
   using type = to<Ts...>;

--- a/rigid_geometric_algebra/detail/type_product.hpp
+++ b/rigid_geometric_algebra/detail/type_product.hpp
@@ -13,9 +13,10 @@ template <
     class Tuple1,
     class Tuple2,
     std::size_t M = std::tuple_size_v<Tuple2>>
-constexpr auto ith_pair(const Tuple1& tuple1, const Tuple2& tuple2)
-    -> std::pair<std::tuple_element_t<I / M, Tuple1>,
-                 std::tuple_element_t<I % M, Tuple2>>;
+constexpr auto
+ith_pair(const Tuple1& tuple1, const Tuple2& tuple2) -> std::pair<
+    std::tuple_element_t<I / M, Tuple1>,
+    std::tuple_element_t<I % M, Tuple2>>;
 
 /// defines the cartesian product of two type lists
 ///
@@ -28,10 +29,8 @@ struct type_product
 {};
 
 template <
-    template <class...>
-    class list1,
-    template <class...>
-    class list2,
+    template <class...> class list1,
+    template <class...> class list2,
     class... T1s,
     class... T2s>
 struct type_product<list1<T1s...>, list2<T2s...>>

--- a/rigid_geometric_algebra/get_or.hpp
+++ b/rigid_geometric_algebra/get_or.hpp
@@ -28,11 +28,10 @@ class get_or_fn
 public:
   template <class V, class U>
     requires detail::has_value_v<std::tuple_size<std::remove_cvref_t<V>>>
-  constexpr static auto operator()(V&& v, U&& u) ->
-      typename std::conditional_t<
-          std::is_invocable_v<decltype(get<B>), V&&>,
-          std::invoke_result<decltype(get<B>), V&&>,
-          std::type_identity<U&&>>::type
+  constexpr static auto operator()(V&& v, U&& u) -> typename std::conditional_t<
+      std::is_invocable_v<decltype(get<B>), V&&>,
+      std::invoke_result<decltype(get<B>), V&&>,
+      std::type_identity<U&&>>::type
   {
     if constexpr (std::is_invocable_v<decltype(get<B>), V>) {
       return get<B>(std::forward<V>(v));

--- a/rigid_geometric_algebra/multivector.hpp
+++ b/rigid_geometric_algebra/multivector.hpp
@@ -200,14 +200,13 @@ public:
       detail::multivector_promotable V2>
     requires (detail::decays_to<V1, multivector> !=
               detail::decays_to<V2, multivector>) and
-                 (not detail::is_defined_v<
-                     detail::overload<std::plus<>, V1, V2>>)
-  friend constexpr auto operator+(V1&& v1, V2&& v2) ->
-      typename detail::type_concat_t<
-          typename std::remove_cvref_t<to_multivector_t<V1>>::blade_list_type,
-          typename std::remove_cvref_t<to_multivector_t<V2>>::blade_list_type>::
-          template insert_into_t<sorted_canonical_blades<>>::
-              template insert_into_t<multivector<algebra_type>>
+             (not detail::is_defined_v<detail::overload<std::plus<>, V1, V2>>)
+  friend constexpr auto
+  operator+(V1&& v1, V2&& v2) -> typename detail::type_concat_t<
+      typename std::remove_cvref_t<to_multivector_t<V1>>::blade_list_type,
+      typename std::remove_cvref_t<to_multivector_t<V2>>::blade_list_type>::
+      template insert_into_t<sorted_canonical_blades<>>::template insert_into_t<
+          multivector<algebra_type>>
   {
     using result_blade_list_type = typename detail::type_concat_t<
         typename std::remove_cvref_t<to_multivector_t<V1>>::blade_list_type,
@@ -322,9 +321,9 @@ template <
     detail::blade B2,
     class A = common_algebra_type_t<B1, B2>>
   requires (not std::is_same_v<canonical_type_t<B1>, canonical_type_t<B2>>)
-constexpr auto operator+(B1&& b1, B2&& b2)
-    -> sorted_canonical_blades_t<canonical_type_t<B1>, canonical_type_t<B2>>::
-        template insert_into_t<multivector<A>>
+constexpr auto operator+(B1&& b1, B2&& b2) -> sorted_canonical_blades_t<
+    canonical_type_t<B1>,
+    canonical_type_t<B2>>::template insert_into_t<multivector<A>>
 {
   if constexpr (
       blade_ordering{std::type_identity<B1>{}} <

--- a/rigid_geometric_algebra/sorted_canonical_blades.hpp
+++ b/rigid_geometric_algebra/sorted_canonical_blades.hpp
@@ -47,9 +47,8 @@ struct sorted_canonical_blades
   static_assert(sorted_blades.second != 0);
 
   template <std::size_t... Is>
-  static constexpr auto impl(std::index_sequence<Is...>)
-      -> detail::type_list<
-          blade_type_from_t<std::get<Is>(sorted_blades.first)>...>;
+  static constexpr auto impl(std::index_sequence<Is...>) -> detail::type_list<
+      blade_type_from_t<std::get<Is>(sorted_blades.first)>...>;
 
   using type = decltype(impl(std::make_index_sequence<sorted_blades.second>{}));
 };

--- a/rigid_geometric_algebra/zero_constant.hpp
+++ b/rigid_geometric_algebra/zero_constant.hpp
@@ -34,8 +34,8 @@ struct zero_constant : detail::derive_subtraction<zero_constant<A>>
   ///
   template <class T1, class T2>
     requires has_common_algebra_type_v<T1, T2> and
-                 (std::is_same_v<zero_constant, T1> or
-                  std::is_same_v<zero_constant, T2>)
+             (std::is_same_v<zero_constant, T1> or
+              std::is_same_v<zero_constant, T2>)
   friend constexpr auto
   operator^(const T1&, const T2&) noexcept -> zero_constant
   {
@@ -60,11 +60,10 @@ struct zero_constant : detail::derive_subtraction<zero_constant<A>>
   ///
   template <class T1, class T2>
     requires has_common_algebra_type_v<T1, T2> and
-                 (detail::decays_to<T1, zero_constant> !=
-                  detail::decays_to<T2, zero_constant>)
-  friend constexpr auto operator+(T1&& lhs, T2&& rhs)
-      -> std::remove_cvref_t<
-          std::conditional_t<detail::decays_to<T2, zero_constant>, T1, T2>>
+             (detail::decays_to<T1, zero_constant> !=
+              detail::decays_to<T2, zero_constant>)
+  friend constexpr auto operator+(T1&& lhs, T2&& rhs) -> std::remove_cvref_t<
+      std::conditional_t<detail::decays_to<T2, zero_constant>, T1, T2>>
   {
     if constexpr (detail::decays_to<T2, zero_constant>) {
       return std::forward<T1>(lhs);

--- a/test/complement_test.cpp
+++ b/test/complement_test.cpp
@@ -48,7 +48,7 @@ auto main() -> int
           G2::blade<1>{},
           G3::blade<1, 2>{},
           GS2::blade<>{},
-          GS2::blade<1>{}} = []<class B>(B b) {
+          GS2::blade<1>{}} = []<class B>(const B& b) {
     using T = typename B::value_type;
     return expect(
         eq(T{}, complement(left, b).coefficient) and

--- a/test/points_example.cpp
+++ b/test/points_example.cpp
@@ -11,5 +11,5 @@ auto main() -> int
   const auto points = std::vector<G2::point>{
       {1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {4, 5, 6}, {5, 6, 7}};
 
-  std::cout << glz::write_json(points).value() << "\n";
+  std::cout << *glz::write_json(points) << "\n";
 }

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -7,10 +7,10 @@ alias(
 )
 
 alias(
-    name = "clang18_toolchain",
+    name = "clang19_toolchain",
     actual = select({
-        "@platforms//os:macos": "@llvm18_toolchain//:cc-toolchain-aarch64-darwin",
-        "@platforms//os:linux": "@llvm18_toolchain//:cc-toolchain-x86_64-linux",
+        "@platforms//os:macos": "@llvm19_toolchain//:cc-toolchain-aarch64-darwin",
+        "@platforms//os:linux": "@llvm19_toolchain//:cc-toolchain-x86_64-linux",
     }),
 )
 
@@ -135,7 +135,7 @@ echo "cd \\$$BUILD_WORKSPACE_DIRECTORY" >> $@
 echo "exec bazel build {options} \\$${{@:-//...}}" >> $@
 """.format(
         options = " ".join([
-            "--extra_toolchains=//tools:clang18_toolchain",
+            "--extra_toolchains=//tools:clang19_toolchain",
             "--aspects=@rules_clang_tidy//:aspects.bzl%check",
             "--output_groups=report",
             "--keep_going",


### PR DESCRIPTION
Update LLVM to 19.1.0. Changes in this commit are due to:
* format updates from clang-format-19
* fix for `performance-unnecessary-value-param` in clang-tidy-19
* restore clang-tidy checks that no longer produce false positives
* replacing `std::expected::value()` with `std::expected::operator*()`
  due to undefined symbols on macOS:

  Undefined symbols for architecture arm64:
  "std::__1::bad_expected_access<void>::what() const", referenced from:
      vtable for std::__1::bad_expected_access<glz::error_ctx> in points_example.o
  "typeinfo for std::__1::bad_expected_access<void>", referenced from:
      typeinfo for std::__1::bad_expected_access<glz::error_ctx> in points_example.o
  "vtable for std::__1::bad_expected_access<void>", referenced from:
      std::__1::bad_expected_access<void>::bad_expected_access[abi:se190100]() in points_example.o
   NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.

Change-Id: Ic80cb489995056c46e0c08a9f64287d98a699375