### PR TITLE
remove libtinfo install step from ci setup

### DIFF
--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -13,12 +13,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: install libtinfo5
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        sudo apt-get install -y libtinfo5
-
     - name: setup ci bazelrc
       shell: bash
       run: |


### PR DESCRIPTION
terminfo is no longer a dependency
https://github.com/llvm/llvm-project/pull/93889

Change-Id: Idf3d7a47e67bb994c505d0bedf5e0ce341de2e1d