### PR TITLE
construct `blade_ordering` from dimension mask

### DIFF
--- a/rigid_geometric_algebra/blade_ordering.hpp
+++ b/rigid_geometric_algebra/blade_ordering.hpp
@@ -1,15 +1,10 @@
 #pragma once
 
 #include "rigid_geometric_algebra/algebra_dimension.hpp"
-#include "rigid_geometric_algebra/algebra_type.hpp"
-#include "rigid_geometric_algebra/blade.hpp"
 #include "rigid_geometric_algebra/detail/structural_bitset.hpp"
-#include "rigid_geometric_algebra/is_algebra.hpp"
-#include "rigid_geometric_algebra/is_blade.hpp"
 
 #include <compare>
 #include <cstddef>
-#include <type_traits>
 
 namespace rigid_geometric_algebra {
 
@@ -26,18 +21,13 @@ struct blade_ordering
   ///
   mask_type mask{};
 
-  /// construct a `blade_ordering` from a blade type
+  /// construct with empty mask
   ///
-  template <std::size_t... Is>
-  constexpr blade_ordering(std::type_identity<blade<A, Is...>>) noexcept
-      : mask{(mask_type{}.set(Is) | ... | mask_type{})}
-  {}
+  blade_ordering() = default;
 
-  template <detail::blade B>
-    requires has_common_algebra_type_v<B, blade_ordering>
-  constexpr blade_ordering(std::type_identity<B>) noexcept
-      : blade_ordering(std::type_identity<std::remove_cvref_t<B>>{})
-  {}
+  /// construct from mask
+  ///
+  constexpr blade_ordering(mask_type mask) : mask{mask} {}
 
   /// equality operator
   ///
@@ -63,12 +53,5 @@ struct blade_ordering
     return lhs.mask.to_unsigned() <=> rhs.mask.to_unsigned();
   }
 };
-
-template <class A>
-  requires is_algebra_v<A>
-blade_ordering(std::type_identity<A>) -> blade_ordering<A>;
-
-template <detail::blade B>
-blade_ordering(std::type_identity<B>) -> blade_ordering<algebra_type_t<B>>;
 
 }  // namespace rigid_geometric_algebra

--- a/rigid_geometric_algebra/is_canonical_blade_order.hpp
+++ b/rigid_geometric_algebra/is_canonical_blade_order.hpp
@@ -40,8 +40,8 @@ public:
         (std::is_same_v<Bs, canonical_type_t<Bs>> and ...) and
         has_common_algebra_type_v<Bs...>) {
       using A = common_algebra_type_t<Bs...>;
-      const auto data = std::array<blade_ordering<A>, sizeof...(Bs)>{
-          std::type_identity<Bs>{}...};
+      const auto data =
+          std::array<blade_ordering<A>, sizeof...(Bs)>{Bs::dimension_mask...};
       return std::ranges::is_sorted(data, std::ranges::less_equal{});
     }
 

--- a/rigid_geometric_algebra/multivector.hpp
+++ b/rigid_geometric_algebra/multivector.hpp
@@ -326,8 +326,8 @@ constexpr auto operator+(B1&& b1, B2&& b2) -> sorted_canonical_blades_t<
     canonical_type_t<B2>>::template insert_into_t<multivector<A>>
 {
   if constexpr (
-      blade_ordering{std::type_identity<B1>{}} <
-      blade_ordering{std::type_identity<B2>{}}) {
+      blade_ordering<A>{std::remove_cvref_t<B1>::dimension_mask} <
+      blade_ordering<A>{std::remove_cvref_t<B2>::dimension_mask}) {
     return {std::forward<B1>(b1).canonical(), std::forward<B2>(b2).canonical()};
   } else {
     return {std::forward<B2>(b2).canonical(), std::forward<B1>(b1).canonical()};

--- a/rigid_geometric_algebra/sorted_canonical_blades.hpp
+++ b/rigid_geometric_algebra/sorted_canonical_blades.hpp
@@ -38,7 +38,7 @@ struct sorted_canonical_blades
   using A = common_algebra_type_t<Bs...>;
 
   static constexpr auto sorted = [] {
-    auto values = std::array{blade_ordering{std::type_identity<Bs>{}}...};
+    auto values = std::array{blade_ordering<A>{Bs::dimension_mask}...};
     std::ranges::sort(values);
     const auto duplicates = std::ranges::unique(values);
     return detail::array_subset(values, values.size() - duplicates.size());

--- a/test/blade_ordering_test.cpp
+++ b/test/blade_ordering_test.cpp
@@ -2,13 +2,12 @@
 #include "skytest/skytest.hpp"
 
 #include <cstddef>
-#include <type_traits>
 
-using rga = ::rigid_geometric_algebra::algebra<double, 2>;
+using G2 = ::rigid_geometric_algebra::algebra<double, 2>;
 using ::rigid_geometric_algebra::blade_ordering;
 
 template <std::size_t... Is>
-constexpr auto ord = blade_ordering{std::type_identity<rga::blade<Is...>>{}};
+constexpr auto ord = blade_ordering<G2>{G2::blade<Is...>::dimension_mask};
 
 auto main() -> int
 {

--- a/test/blade_type_from_test.cpp
+++ b/test/blade_type_from_test.cpp
@@ -1,8 +1,6 @@
 #include "rigid_geometric_algebra/rigid_geometric_algebra.hpp"
 #include "skytest/skytest.hpp"
 
-#include <type_traits>
-
 template <class Out, class In>
 struct impl
 {
@@ -12,10 +10,7 @@ struct impl
     using ::rigid_geometric_algebra::blade_ordering;
     using ::rigid_geometric_algebra::blade_type_from_t;
 
-    return Out{} ==
-           blade_type_from_t<
-               algebra_type_t<In>,
-               blade_ordering{std::type_identity<In>{}}.mask>{};
+    return Out{} == blade_type_from_t<algebra_type_t<In>, In::dimension_mask>{};
   }
 };
 


### PR DESCRIPTION
Replace `type_identity` constructors. Add dimensions mask a static
member to `blade`.

Change-Id: Ib56ab207963942c9c542449ce984d1f00062f19f