### PR TITLE
simplify usage of `blade_type_from_*` traits

### DIFF
--- a/rigid_geometric_algebra/blade_complement_type.hpp
+++ b/rigid_geometric_algebra/blade_complement_type.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rigid_geometric_algebra/blade_type_from.hpp"
 #include "rigid_geometric_algebra/detail/disjoint_subset.hpp"
 #include "rigid_geometric_algebra/is_blade.hpp"
 
@@ -25,12 +26,7 @@ struct blade_complement_type_<true, blade_<A, Is...>>
         return detail::disjoint_subset(Is..., Js...);
       }(std::make_index_sequence<algebra_dimension_v<A>>{});
 
-  template <std::size_t... Ks>
-  static constexpr auto type_impl(std::index_sequence<Ks...>)
-      -> blade_<A, complement_dimensions[Ks]...>;
-
-  using type = decltype(type_impl(
-      std::make_index_sequence<complement_dimensions.size()>{}));
+  using type = blade_type_from_dimensions_t<A, complement_dimensions>;
 };
 
 }  // namespace detail

--- a/rigid_geometric_algebra/blade_type_from.hpp
+++ b/rigid_geometric_algebra/blade_type_from.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "rigid_geometric_algebra/blade.hpp"
+#include "rigid_geometric_algebra/detail/array_subset.hpp"
 #include "rigid_geometric_algebra/detail/indices_array.hpp"
-#include "rigid_geometric_algebra/is_algebra.hpp"
+#include "rigid_geometric_algebra/detail/structural_bitset.hpp"
 
 #include <cstddef>
-#include <ranges>
 #include <utility>
 
 namespace rigid_geometric_algebra {
@@ -17,14 +17,15 @@ namespace rigid_geometric_algebra {
 /// ~~~{.cpp}
 /// static_assert(std::is_same_v<
 ///   blade<A, 0, 2, 1>,
-///   blade_type_from_dimensions_t<A, std::array{0, 2, 1}>
+///   blade_type_from_dimensions_t<A, {0, 2, 1}>
 /// >);
 /// ~~~
 ///
 /// @{
 
-template <class A, std::ranges::random_access_range auto dimensions>
-  requires is_algebra_v<A>
+template <
+    class A,
+    detail::array_subset<std::size_t, algebra_dimension_v<A>> dimensions>
 struct blade_type_from_dimensions
 {
   using type =
@@ -34,45 +35,34 @@ struct blade_type_from_dimensions
       }(std::make_index_sequence<dimensions.size()>{}));
 };
 
-template <class A, auto dimensions>
+template <
+    class A,
+    detail::array_subset<std::size_t, algebra_dimension_v<A>> dimensions>
 using blade_type_from_dimensions_t =
     typename blade_type_from_dimensions<A, dimensions>::type;
 
 /// @}
 
-/// determine the blade type from a dimension mask or range of dimensions
+/// determine the blade type from a dimension mask
 /// @tparam A algebra type
-/// @tparam mask_or_dimensions forward range of `bool` or random access range
-/// of dimensions
+/// @tparam mask range of `bool`
 ///
-/// Determins the `blade` type given an algebra type and either a mask or
-/// dimensions. If `mask_or_dimensions` has a range value type of `bool`, it is
-/// interpreted as a mask. Otherwise, it is interpreted as dimensions.
+/// Determins the `blade` type given an algebra type and a mask of dimensions.
+/// Each bool in the mask correspond to a dimension, starting dimension 0.
 ///
-/// @note The `blade` type given a mask is always in canonical form.
+/// @note The `blade` type is always in canonical form.
 ///
 /// @{
 
-template <class A, std::ranges::forward_range auto mask_or_dimensions>
-  requires is_algebra_v<A>
-struct blade_type_from
+template <class A, detail::structural_bitset<algebra_dimension_v<A>> mask>
+struct blade_type_from_mask
 {
-  using type = typename decltype([] {
-    if constexpr (
-        std::is_same_v<
-            bool,
-            std::ranges::range_value_t<decltype(mask_or_dimensions)>>) {
-      static constexpr auto dimensions =
-          detail::indices_array<mask_or_dimensions>;
-      return blade_type_from_dimensions<A, dimensions>{};
-    } else {
-      return blade_type_from_dimensions<A, mask_or_dimensions>{};
-    }
-  }())::type;
+  static constexpr auto dimensions = detail::indices_array<mask>;
+  using type = blade_type_from_dimensions_t<A, dimensions>;
 };
 
-template <class A, auto mask_or_dimensions>
-using blade_type_from_t = typename blade_type_from<A, mask_or_dimensions>::type;
+template <class A, detail::structural_bitset<algebra_dimension_v<A>> mask>
+using blade_type_from_mask_t = typename blade_type_from_mask<A, mask>::type;
 
 /// @}
 

--- a/rigid_geometric_algebra/detail/array_subset.hpp
+++ b/rigid_geometric_algebra/detail/array_subset.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
 #include "rigid_geometric_algebra/detail/contract.hpp"
+#include "rigid_geometric_algebra/detail/decays_to.hpp"
 
+#include <algorithm>
 #include <array>
+#include <concepts>
 #include <cstddef>
+#include <initializer_list>
+#include <iterator>
 #include <ranges>
 
 namespace rigid_geometric_algebra::detail {
@@ -19,16 +24,29 @@ template <class T, std::size_t Capacity>
 class array_subset
     : public std::ranges::view_interface<array_subset<T, Capacity>>
 {
+public:
   using base_type = std::array<T, Capacity>;
   base_type base_{};
   std::size_t size_{};
 
-public:
-  constexpr array_subset(const base_type& base, std::size_t size)
-      : base_{base}, size_{size}
+  template <std::ranges::random_access_range R>
+    requires (not detail::decays_to<R, array_subset>) and
+             std::constructible_from<T, std::ranges::range_value_t<R>>
+  // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
+  constexpr array_subset(R&& rng) : size_{rng.size()}
   {
-    detail::precondition(size_ <= Capacity);
+    detail::precondition(rng.size() <= Capacity);
+    std::ranges::move(rng, base_.begin());
   }
+
+  template <std::random_access_iterator I, std::sentinel_for<I> S>
+  constexpr array_subset(I first, S last)
+      : array_subset{std::ranges::subrange{first, last}}
+  {}
+
+  constexpr array_subset(std::initializer_list<std::size_t> il)
+      : array_subset{std::ranges::subrange{il.begin(), il.end()}}
+  {}
 
   constexpr auto begin() const noexcept { return base_.begin(); }
   constexpr auto end() const noexcept { return begin() + size_; }

--- a/rigid_geometric_algebra/detail/disjoint_subset.hpp
+++ b/rigid_geometric_algebra/detail/disjoint_subset.hpp
@@ -49,7 +49,7 @@ public:
       pending = {pending.begin(), last};
     }
 
-    return {dims, static_cast<std::size_t>(pending.begin() - dims.begin())};
+    return {dims.begin(), pending.begin()};
   }
 
 } disjoint_subset{};

--- a/rigid_geometric_algebra/rigid_geometric_algebra.hpp
+++ b/rigid_geometric_algebra/rigid_geometric_algebra.hpp
@@ -19,6 +19,7 @@ namespace rigid_geometric_algebra {}  // namespace rigid_geometric_algebra
 #include "rigid_geometric_algebra/blade.hpp"
 #include "rigid_geometric_algebra/blade_complement_type.hpp"
 #include "rigid_geometric_algebra/blade_sum.hpp"
+#include "rigid_geometric_algebra/blade_type_from.hpp"
 #include "rigid_geometric_algebra/canonical_type.hpp"
 #include "rigid_geometric_algebra/complement.hpp"
 #include "rigid_geometric_algebra/field.hpp"

--- a/rigid_geometric_algebra/scalar_type.hpp
+++ b/rigid_geometric_algebra/scalar_type.hpp
@@ -2,10 +2,11 @@
 
 #include "rigid_geometric_algebra/algebra_dimension.hpp"
 #include "rigid_geometric_algebra/blade.hpp"
+#include "rigid_geometric_algebra/blade_type_from.hpp"
 #include "rigid_geometric_algebra/is_algebra.hpp"
 
 #include <cstddef>
-#include <utility>
+#include <ranges>
 
 namespace rigid_geometric_algebra {
 
@@ -28,11 +29,9 @@ struct antiscalar_
 template <class A>
 struct antiscalar_<true, A>
 {
-  using type =
-      decltype([]<std::size_t... Is>(std::index_sequence<Is...>)
-                   -> ::rigid_geometric_algebra::blade<A, Is...> {
-        return {};
-      }(std::make_index_sequence<algebra_dimension_v<A>>{}));
+  using type = blade_type_from_dimensions_t<
+      A,
+      std::views::iota(0UZ, algebra_dimension_v<A>)>;
 };
 
 }  // namespace detail

--- a/rigid_geometric_algebra/sorted_canonical_blades.hpp
+++ b/rigid_geometric_algebra/sorted_canonical_blades.hpp
@@ -38,17 +38,20 @@ struct sorted_canonical_blades
   using A = common_algebra_type_t<Bs...>;
 
   static constexpr auto sorted = [] {
-    auto values = std::array{blade_ordering<A>{Bs::dimension_mask}...};
-    std::ranges::sort(values);
-    const auto duplicates = std::ranges::unique(values);
-    return detail::array_subset(values, values.size() - duplicates.size());
+    auto blades = std::array{blade_ordering<A>{Bs::dimension_mask}...};
+
+    std::ranges::sort(blades);
+    const auto [last, _] = std::ranges::unique(blades);
+
+    return detail::array_subset<blade_ordering<A>, sizeof...(Bs)>{
+        blades.begin(), last};
   }();
 
   static_assert(sorted.size() != 0);
 
   template <std::size_t... Is>
   static constexpr auto impl(std::index_sequence<Is...>)
-      -> detail::type_list<blade_type_from_t<A, sorted[Is].mask>...>;
+      -> detail::type_list<blade_type_from_mask_t<A, sorted[Is].mask>...>;
 
   using type = decltype(impl(std::make_index_sequence<sorted.size()>{}));
 };

--- a/rigid_geometric_algebra/wedge.hpp
+++ b/rigid_geometric_algebra/wedge.hpp
@@ -31,11 +31,11 @@ class wedge_blade_fn
   using blade_result_t = decltype([] {
     using A = common_algebra_type_t<B1, B2>;
 
-    static constexpr auto joined =
+    static constexpr auto mask =
         (std::remove_cvref_t<B1>::dimension_mask |
          std::remove_cvref_t<B2>::dimension_mask);
 
-    return blade_type_from_t<A, joined>{};
+    return blade_type_from_mask_t<A, mask>{};
   }());
 
 public:

--- a/test/blade_type_from_test.cpp
+++ b/test/blade_type_from_test.cpp
@@ -1,21 +1,18 @@
 #include "rigid_geometric_algebra/rigid_geometric_algebra.hpp"
 #include "skytest/skytest.hpp"
 
-template <class Out, class In>
-struct impl
-{
-  constexpr operator bool() const
-  {
-    using ::rigid_geometric_algebra::algebra_type_t;
-    using ::rigid_geometric_algebra::blade_ordering;
-    using ::rigid_geometric_algebra::blade_type_from_t;
+#include <type_traits>
 
-    return Out{} == blade_type_from_t<algebra_type_t<In>, In::dimension_mask>{};
-  }
-};
+template <class T1, class T2>
+static constexpr auto same = ::skytest::pred(std::is_same<T1, T2>{});
 
 template <class Out, class In>
-static constexpr auto test_blade_type_from = impl<Out, In>{};
+static constexpr auto test_blade_type_from = ::skytest::pred(
+    std::is_same<
+        Out,
+        ::rigid_geometric_algebra::blade_type_from_mask_t<
+            ::rigid_geometric_algebra::algebra_type_t<In>,
+            In::dimension_mask>>{});
 
 auto main() -> int
 {
@@ -28,18 +25,40 @@ auto main() -> int
 
   "blade type from ordering"_test = [] {
     return expect(
-        test_blade_type_from<G2::blade<>, G2::blade<>> and
-        test_blade_type_from<G2::blade<0>, G2::blade<0>> and
-        test_blade_type_from<G2::blade<1>, G2::blade<1>> and
-        test_blade_type_from<G2::blade<2>, G2::blade<2>> and
-        test_blade_type_from<G2::blade<0, 1, 2>, G2::blade<0, 1, 2>>);
+        test_blade_type_from<G2::blade<>, G2::blade<>>() and
+        test_blade_type_from<G2::blade<0>, G2::blade<0>>() and
+        test_blade_type_from<G2::blade<1>, G2::blade<1>>() and
+        test_blade_type_from<G2::blade<2>, G2::blade<2>>() and
+        test_blade_type_from<G2::blade<0, 1, 2>, G2::blade<0, 1, 2>>());
   };
 
   "blade type from ordering is canonical"_test = [] {
     return expect(
-        test_blade_type_from<G2::blade<0, 1>, G2::blade<0, 1>> and
-        test_blade_type_from<G2::blade<0, 1>, G2::blade<1, 0>> and
-        test_blade_type_from<G2::blade<0, 1, 2>, G2::blade<2, 1, 0>> and
-        test_blade_type_from<G2::blade<0, 1, 2>, G2::blade<1, 0, 2>>);
+        test_blade_type_from<G2::blade<0, 1>, G2::blade<0, 1>>() and
+        test_blade_type_from<G2::blade<0, 1>, G2::blade<1, 0>>() and
+        test_blade_type_from<G2::blade<0, 1, 2>, G2::blade<2, 1, 0>>() and
+        test_blade_type_from<G2::blade<0, 1, 2>, G2::blade<1, 0, 2>>());
+  };
+
+  "blade type from mask"_test = [] {
+    using ::rigid_geometric_algebra::blade_type_from_mask_t;
+
+    return expect(
+        same<G2::blade<0, 1, 2>, blade_type_from_mask_t<G2, 0b111>>() and
+        (not same<G2::blade<2, 1, 0>, blade_type_from_mask_t<G2, 0b111>>()) and
+        same<G2::blade<0, 1>, blade_type_from_mask_t<G2, 0b011>>() and
+        same<G2::blade<0, 1>, blade_type_from_mask_t<G2, 0b11>>() and
+        same<G2::blade<1, 2>, blade_type_from_mask_t<G2, 0b110>>());
+  };
+
+  "blade type from dimensions"_test = [] {
+    using ::rigid_geometric_algebra::blade_type_from_dimensions_t;
+
+    return expect(
+        same<G2::blade<>, blade_type_from_dimensions_t<G2, {}>>() and
+        same<G2::blade<0>, blade_type_from_dimensions_t<G2, {0}>>() and
+        same<G2::blade<1, 2>, blade_type_from_dimensions_t<G2, {1, 2}>>() and
+        same<G2::blade<2, 1, 0>,
+             blade_type_from_dimensions_t<G2, {2, 1, 0}>>());
   };
 }

--- a/test/detail/structural_bitset_test.cpp
+++ b/test/detail/structural_bitset_test.cpp
@@ -16,6 +16,10 @@ auto main() -> int
 
   using B2 = structural_bitset<2>;
 
+  "bits constructor pre"_test = [] {
+    return expect(aborts([] { B2{0b1000}; }));
+  };
+
   "set pre"_test = [] { return expect(aborts([] { B2{}.set(4); })); };
 
   "set"_test = [] {


### PR DESCRIPTION
Allow use of ranges with `blade_type_from_dimensions` and unsigned
integers with `blade_type_from_mask` traits. These traits now specify
the non-type template paramter to be `detail::array_subset` and
`detail::structural_bitset` respectively.

This commit also provides converting constructors for
`detail::array_subset` and `detail::structural_bitset` and makes changes
necessary to meet the criteria of a structural type.

Change-Id: I729e67cdf36f0a20d4ff638ef2cdf37943620116