### PR TITLE
fix blade order

### DIFF
--- a/rigid_geometric_algebra/detail/structural_bitset.hpp
+++ b/rigid_geometric_algebra/detail/structural_bitset.hpp
@@ -109,6 +109,16 @@ struct structural_bitset
     return std::forward<Self>(self);
   }
 
+  template <class Self>
+    requires (not std::is_const_v<std::remove_reference_t<Self>>)
+  constexpr auto reset(this Self&& self, std::size_t pos) -> Self&&
+  {
+    detail::precondition(
+        pos < size, "`pos` exceeds number of bits in `structural_bitset`");
+    self.value_ &= ~(std::uint8_t{1} << pos);
+    return std::forward<Self>(self);
+  }
+
   /// returns the number of bits set to `true`
   ///
   [[nodiscard]]

--- a/test/blade_ordering_test.cpp
+++ b/test/blade_ordering_test.cpp
@@ -4,10 +4,14 @@
 #include <cstddef>
 
 using G2 = ::rigid_geometric_algebra::algebra<double, 2>;
+using G3 = ::rigid_geometric_algebra::algebra<double, 3>;
 using ::rigid_geometric_algebra::blade_ordering;
 
 template <std::size_t... Is>
 constexpr auto ord = blade_ordering<G2>{G2::blade<Is...>::dimension_mask};
+
+template <std::size_t... Is>
+constexpr auto ord3 = blade_ordering<G3>{G3::blade<Is...>::dimension_mask};
 
 auto main() -> int
 {
@@ -22,10 +26,21 @@ auto main() -> int
         eq(ord<0, 1, 2>, ord<0, 2, 1>));
   };
 
-  "lt"_test = [] {
+  "lt (G2)"_test = [] {
     return expect(
-        lt(ord<>, ord<0>) and lt(ord<0>, ord<1>) and lt(ord<1>, ord<2>) and
-        lt(ord<>, ord<2>) and lt(ord<0, 1>, ord<0, 2>) and
-        lt(ord<0, 2>, ord<1, 2>) and lt(ord<1, 2>, ord<0, 1, 2>));
+        lt(ord<>, ord<0>) and         //
+        lt(ord<0>, ord<1>) and        //
+        lt(ord<1>, ord<2>) and        //
+        lt(ord<>, ord<2>) and         //
+        lt(ord<0, 1>, ord<0, 2>) and  //
+        lt(ord<0, 2>, ord<1, 2>) and  //
+        lt(ord<1, 2>, ord<0, 1, 2>));
+  };
+
+  "lt (G3)"_test = [] {
+    return expect(
+        lt(ord3<0, 3>, ord3<1, 2>) and  //
+        lt(ord3<2, 3>, ord3<3, 1>) and  //
+        lt(ord3<3, 1>, ord3<1, 2>));
   };
 }

--- a/test/detail/structural_bitset_test.cpp
+++ b/test/detail/structural_bitset_test.cpp
@@ -39,6 +39,14 @@ auto main() -> int
         eq(1, B2{}.set(1).count()) and eq(2, B2{}.set(0).set(1).count()));
   };
 
+  "reset"_test = [] {
+    return expect(
+        eq(B2{0b10}, B2{0b11}.reset(0)) and eq(B2{0b01}, B2{0b11}.reset(1)) and
+        eq(B2{0b00}, B2{0b11}.reset(0).reset(1)) and
+        eq(B2{0b10}, B2{0b11}.reset(0).reset(0)) and
+        eq(B2{0b01}, B2{0b11}.reset(1).reset(1)));
+  };
+
   "test pre"_test = [] {
     return expect(aborts([] { std::ignore = B2{}.test(4); }));
   };

--- a/test/sorted_canonical_blades_test.cpp
+++ b/test/sorted_canonical_blades_test.cpp
@@ -1,11 +1,45 @@
 #include "rigid_geometric_algebra/rigid_geometric_algebra.hpp"
+
+#include <format>
+#include <iterator>
+#include <ostream>
+#include <vector>
+
+namespace {
+
+// skytest doesn't handle printing ranges-of-ranges
+template <class T>
+auto operator<<(std::ostream& os, const std::vector<T>& v) -> std::ostream&
+{
+  auto out = std::ostream_iterator<char>(os);
+  std::format_to(out, "{}", v);
+  return os;
+}
+
+}  // namespace
+
 #include "skytest/skytest.hpp"
 
+#include <algorithm>
+#include <ranges>
 #include <type_traits>
 
 using G2 = ::rigid_geometric_algebra::algebra<double, 2>;
+using G3 = ::rigid_geometric_algebra::algebra<double, 3>;
 using ::rigid_geometric_algebra::sorted_canonical_blades_t;
 using ::rigid_geometric_algebra::detail::type_list;
+
+template <class T1, class T2>
+static constexpr auto same = ::skytest::pred(std::is_same<T1, T2>{});
+
+static constexpr auto to_range = []<class... Bs>(type_list<Bs...>) {
+  return std::vector{std::vector{std::from_range, Bs::dimensions}...};
+};
+
+template <class T1, class T2>
+static constexpr auto equal = [] {
+  return ::skytest::pred(std::ranges::equal)(to_range(T1{}), to_range(T2{}));
+};
 
 auto main() -> int
 {
@@ -15,7 +49,7 @@ auto main() -> int
 
   "not in order"_test = [] {
     return expect(
-        std::is_same_v<
+        same<
             type_list<
                 G2::blade<>,
                 G2::blade<0>,
@@ -33,18 +67,61 @@ auto main() -> int
                 G2::blade<0, 1>,
                 G2::blade<0, 2>,
                 G2::blade<1, 2>,
-                G2::blade<0, 1, 2>>>);
+                G2::blade<0, 1, 2>>>());
+  };
+
+  "point blade order"_test = [] {
+    return expect(
+        same<type_list<G3::blade<0>, G3::blade<1>, G3::blade<2>, G3::blade<3>>,
+             sorted_canonical_blades_t<
+                 G3::blade<0>,
+                 G3::blade<1>,
+                 G3::blade<2>,
+                 G3::blade<3>>>());
+  };
+
+  "line blade order"_test = [] {
+    return expect(
+        equal<
+            type_list<
+                G3::blade<0, 1>,
+                G3::blade<0, 2>,
+                G3::blade<0, 3>,
+                G3::blade<2, 3>,
+                G3::blade<1, 3>,  // TODO fix basis order
+                G3::blade<1, 2>>,
+            sorted_canonical_blades_t<
+                G3::blade<0, 1>,
+                G3::blade<0, 2>,
+                G3::blade<0, 3>,
+                G3::blade<1, 2>,
+                G3::blade<3, 1>,
+                G3::blade<2, 3>>>());
+  };
+
+  "plane blade order"_test = [] {
+    return expect(
+        equal<
+            type_list<
+                G3::blade<0, 2, 3>,
+                G3::blade<0, 1, 3>,  // TODO fix basis order
+                G3::blade<0, 1, 2>,
+                G3::blade<1, 2, 3>>,  // TODO fix basis order
+            sorted_canonical_blades_t<
+                G3::blade<0, 2, 3>,
+                G3::blade<0, 3, 1>,
+                G3::blade<0, 1, 2>,
+                G3::blade<3, 2, 1>>>());
   };
 
   "has duplicates"_test = [] {
     return expect(
-        std::is_same_v<
-            type_list<G2::blade<>, G2::blade<0>, G2::blade<1>, G2::blade<2>>,
-            sorted_canonical_blades_t<
-                G2::blade<0>,
-                G2::blade<>,
-                G2::blade<>,
-                G2::blade<1>,
-                G2::blade<2>>>);
+        same<type_list<G2::blade<>, G2::blade<0>, G2::blade<1>, G2::blade<2>>,
+             sorted_canonical_blades_t<
+                 G2::blade<0>,
+                 G2::blade<>,
+                 G2::blade<>,
+                 G2::blade<1>,
+                 G2::blade<2>>>());
   };
 }


### PR DESCRIPTION
`blade`s are stored in a `multivector` based on a total order. This
commit updates the `blade` total order to match the blade order of lines
and planes in Lengyel's notation.

This order is well defined up 4 dimension. For blades with basis
dimensions `i...` and `j...`:
- if sizeof...(i) < sizeof...(j), then b_{i...} < b_{j...}
- otherwise if sizeof...(i) == sizeof...(j)
  and if i... contains 0 and j... does not contain 0, then b_{i...} < b_{j...}
- otherwise if i... and j... both contain 0 or both do not contain 0
  and if sizeof...(i) == 1 the ordering of b_{i...} <=> b_{j...} is determined
  by i...[0] <=> j...[0]
- otherwise if sizeof...(i) != 1 the ordering of b_{i...} <=> b_{j...} is
  determined by bitmask(j...).to_unsigned() <=> bitmask(i...).to_unsigned()

For G3 (dimension 4), this order results in the following layouts for
geometric types:
- point: [ weight | position ]
- line: [ direction | moment ]
- plane : [ normal | position ]

Its unclear how blade ordering impacts layout for dimensions
greater than 4.

Change-Id: If6aec4167cd5f6780c609cae333da7fad954d268