### PR TITLE
fix basis dimension order

### DIFF
--- a/rigid_geometric_algebra/BUILD.bazel
+++ b/rigid_geometric_algebra/BUILD.bazel
@@ -16,6 +16,7 @@ cc_library(
         "blade_ordering.hpp",
         "blade_sum.hpp",
         "blade_type_from.hpp",
+        "canonical_dimension_order.hpp",
         "canonical_type.hpp",
         "common_algebra_type.hpp",
         "complement.hpp",

--- a/rigid_geometric_algebra/blade_complement_type.hpp
+++ b/rigid_geometric_algebra/blade_complement_type.hpp
@@ -3,7 +3,6 @@
 #include "rigid_geometric_algebra/algebra_dimension.hpp"
 #include "rigid_geometric_algebra/algebra_type.hpp"
 #include "rigid_geometric_algebra/blade_type_from.hpp"
-#include "rigid_geometric_algebra/canonical_type.hpp"
 #include "rigid_geometric_algebra/is_blade.hpp"
 
 #include <algorithm>
@@ -27,13 +26,14 @@ struct blade_complement_type_<true, B>
   using type = blade_type_from_dimensions_t<A, [] {
     auto missing = std::array<std::size_t, algebra_dimension_v<A> - B::grade>{};
 
+    auto sorted = B::dimensions;
+    std::ranges::sort(sorted);
+
     std::ranges::set_difference(
-        std::views::iota(0UZ, algebra_dimension_v<A>),
-        canonical_type_t<B>::dimensions,
-        missing.begin());
+        std::views::iota(0UZ, algebra_dimension_v<A>), sorted, missing.begin());
 
     return missing;
-  }()>;
+  }()>::canonical_type;
 };
 
 }  // namespace detail

--- a/rigid_geometric_algebra/canonical_dimension_order.hpp
+++ b/rigid_geometric_algebra/canonical_dimension_order.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "rigid_geometric_algebra/detail/contract.hpp"
+#include "rigid_geometric_algebra/detail/counted_sort.hpp"
+#include "rigid_geometric_algebra/detail/even.hpp"
+
+#include <algorithm>
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <iterator>
+#include <ranges>
+
+namespace rigid_geometric_algebra {
+namespace detail {
+
+template <std::size_t N>
+class canonical_dimension_order_fn
+{
+public:
+  template <std::ranges::random_access_range R>
+    requires (std::sortable<std::ranges::iterator_t<R>> and
+              std::same_as<std::size_t, std::ranges::range_value_t<R>>)
+  // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
+  static constexpr auto operator()(R&& dimensions) -> void
+  {
+    detail::precondition(dimensions.size() <= N);
+
+    std::ranges::sort(dimensions);
+
+    // if all dimensions are present, return lexicographic order
+    if (dimensions.size() == N) {
+      return;
+    }
+
+    // skip the first dimension if it is 0
+    const auto first_is_zero =
+        not dimensions.empty() and dimensions.front() == 0;
+    const auto bulk =
+        std::ranges::subrange(dimensions) |
+        std::views::drop(int{first_is_zero});
+
+    // partition all dimensions to
+    // [ bulk | complement(bulk) ]
+    // e.g. N = 4
+    // [ 2, 3 | 0, 1 ]
+    //  or
+    // [ 1, 3 | 0, 2 ]
+    auto partitioned = std::array<std::size_t, N>{};
+    const auto [_, it] = std::ranges::copy(bulk, partitioned.begin());
+    std::ranges::set_difference(std::views::iota(0UZ, N), bulk, it);
+
+    // If sorting [ bulk | complement(bulk) ] requires an odd number of
+    // swaps, reverse the bulk part of dimensions (0 remains the first element
+    // if present). Otherwise, return dimensions (sorted to be in
+    // lexicographic order).
+    if (not detail::even(detail::counted_sort(partitioned))) {
+      std::ranges::reverse(bulk);
+    }
+  }
+};
+
+}  // namespace detail
+
+/// reorders a range of dimensions to canonical order
+/// @tparam N algebra dimension
+///
+/// Reorders dimensions to canonical order. For grade 2 blades without a
+/// 0-dimensional basis, canonical order is equivalent to cyclic order:
+///
+/// ```
+/// (1, 2) -> (1, 2)
+/// (1, 3) -> (3, 1)
+/// (2, 3) -> (2, 3)
+/// ```
+///
+/// This reduces the need to negate blades when performing geometric operations.
+///
+template <std::size_t N>
+inline constexpr auto canonical_dimension_order =
+    detail::canonical_dimension_order_fn<N>{};
+}  // namespace rigid_geometric_algebra

--- a/rigid_geometric_algebra/detail/concat_ranges.hpp
+++ b/rigid_geometric_algebra/detail/concat_ranges.hpp
@@ -19,13 +19,16 @@ public:
   static constexpr auto operator()(const R1& r1, const R2& r2)
       -> std::vector<std::ranges::range_value_t<R1>>
   {
-    auto out = std::vector<std::ranges::range_value_t<R1>>{};
-    out.resize(r1.size() + r2.size());
+    // clang bug with immediate-escalation
+    if consteval {
+      auto out = std::vector<std::ranges::range_value_t<R1>>{};
+      out.resize(r1.size() + r2.size());
 
-    const auto [_, it] = std::ranges::copy(r1, out.begin());
-    std::ranges::copy(r2, it);
+      const auto [_, it] = std::ranges::copy(r1, out.begin());
+      std::ranges::copy(r2, it);
 
-    return out;
+      return out;
+    }
   }
 } concat_ranges{};
 

--- a/rigid_geometric_algebra/multivector.hpp
+++ b/rigid_geometric_algebra/multivector.hpp
@@ -58,6 +58,7 @@ class multivector
   struct blade_set : blade_type_from_dimensions_t<A, D>...
   {};
 
+  // clang bug
   // can't use immediately invoked lambda, likely due to
   // https://github.com/llvm/llvm-project/issues/93327
   // https://www.reddit.com/r/cpp_questions/comments/1961soo/immediatelyinvoked_lambda_in_concept_definition/

--- a/rigid_geometric_algebra/rigid_geometric_algebra.hpp
+++ b/rigid_geometric_algebra/rigid_geometric_algebra.hpp
@@ -21,6 +21,7 @@ namespace rigid_geometric_algebra {}  // namespace rigid_geometric_algebra
 #include "rigid_geometric_algebra/blade_dimensions.hpp"
 #include "rigid_geometric_algebra/blade_sum.hpp"
 #include "rigid_geometric_algebra/blade_type_from.hpp"
+#include "rigid_geometric_algebra/canonical_dimension_order.hpp"
 #include "rigid_geometric_algebra/canonical_type.hpp"
 #include "rigid_geometric_algebra/complement.hpp"
 #include "rigid_geometric_algebra/field.hpp"

--- a/rigid_geometric_algebra/sorted_canonical_blades.hpp
+++ b/rigid_geometric_algebra/sorted_canonical_blades.hpp
@@ -2,6 +2,7 @@
 
 #include "rigid_geometric_algebra/blade_ordering.hpp"
 #include "rigid_geometric_algebra/blade_type_from.hpp"
+#include "rigid_geometric_algebra/canonical_type.hpp"
 #include "rigid_geometric_algebra/common_algebra_type.hpp"
 #include "rigid_geometric_algebra/detail/array_subset.hpp"
 #include "rigid_geometric_algebra/detail/has_type.hpp"
@@ -50,8 +51,8 @@ struct sorted_canonical_blades
   static_assert(sorted.size() != 0);
 
   template <std::size_t... Is>
-  static constexpr auto impl(std::index_sequence<Is...>)
-      -> detail::type_list<blade_type_from_mask_t<A, sorted[Is].mask>...>;
+  static constexpr auto impl(std::index_sequence<Is...>) -> detail::type_list<
+      canonical_type_t<blade_type_from_mask_t<A, sorted[Is].mask>>...>;
 
   using type = decltype(impl(std::make_index_sequence<sorted.size()>{}));
 };

--- a/rigid_geometric_algebra/wedge.hpp
+++ b/rigid_geometric_algebra/wedge.hpp
@@ -35,7 +35,7 @@ class wedge_blade_fn
         (std::remove_cvref_t<B1>::dimension_mask |
          std::remove_cvref_t<B2>::dimension_mask);
 
-    return blade_type_from_mask_t<A, mask>{};
+    return typename blade_type_from_mask_t<A, mask>::canonical_type{};
   }());
 
 public:
@@ -46,7 +46,8 @@ public:
     static constexpr auto num_swaps =
         detail::counted_sort(detail::concat_ranges(
             std::remove_cvref_t<B1>::dimensions,
-            std::remove_cvref_t<B2>::dimensions));
+            std::remove_cvref_t<B2>::dimensions)) +
+        detail::counted_sort(auto{blade_result_t<B1, B2>::dimensions});
 
     return blade_result_t<B1, B2>{detail::negate_if_odd<num_swaps>{}(
         std::forward<B1>(b1).coefficient * std::forward<B2>(b2).coefficient)};

--- a/test/blade_test.cpp
+++ b/test/blade_test.cpp
@@ -3,6 +3,7 @@
 
 #include <format>
 #include <functional>
+#include <type_traits>
 
 auto main() -> int
 {
@@ -14,6 +15,7 @@ auto main() -> int
   using ::skytest::pred;
 
   using G2 = ::rigid_geometric_algebra::algebra<double, 2>;
+  using G3 = ::rigid_geometric_algebra::algebra<double, 3>;
 
   "constructible"_test = [] {
     const auto a = G2::blade<>{};
@@ -65,19 +67,45 @@ auto main() -> int
     return expect(eq(G2::blade<0, 1>{1}, -G2::blade<0, 1>{-1}));
   };
 
-  "canonical form"_test = [] {
+  static constexpr auto equal =
+      []<class T>(const std::type_identity_t<T>& lhs, const T& rhs) {
+        return ::skytest::pred(std::equal_to<>{})(lhs, rhs);
+      };
+
+  "canonical form (G2)"_test = [] {
     return expect(
-        eq(G2::blade<>{}, G2::blade<>{}.canonical()) and
-        eq(G2::blade<0>{}, G2::blade<0>{}.canonical()) and
-        eq(G2::blade<1>{}, G2::blade<1>{}.canonical()) and
-        eq(G2::blade<2>{}, G2::blade<2>{}.canonical()) and
-        eq(G2::blade<0, 1>{}, G2::blade<0, 1>{}.canonical()) and
-        eq(G2::blade<0, 1>{}, G2::blade<1, 0>{}.canonical()) and
-        eq(G2::blade<0, 2>{}, G2::blade<0, 2>{}.canonical()) and
-        eq(G2::blade<0, 2>{}, G2::blade<2, 0>{}.canonical()) and
-        eq(G2::blade<0, 1, 2>{}, G2::blade<0, 2, 1>{}.canonical()) and
-        eq(G2::blade<0, 1, 2>{}, G2::blade<1, 2, 0>{}.canonical()) and
-        eq(G2::blade<0, 1, 2>{}, G2::blade<0, 1, 2>{}.canonical()));
+        equal({}, G2::blade<>::canonical_type::dimensions) and
+        equal({0}, G2::blade<0>::canonical_type::dimensions) and
+        equal({1}, G2::blade<1>::canonical_type::dimensions) and
+        equal({2}, G2::blade<2>::canonical_type::dimensions) and
+        equal({0, 1}, G2::blade<0, 1>::canonical_type::dimensions) and
+        equal({0, 1}, G2::blade<1, 0>::canonical_type::dimensions) and
+        equal({0, 2}, G2::blade<0, 2>::canonical_type::dimensions) and  // FIX
+        equal({0, 2}, G2::blade<2, 0>::canonical_type::dimensions) and  // FIX
+        equal({0, 1, 2}, G2::blade<0, 2, 1>::canonical_type::dimensions) and
+        equal({0, 1, 2}, G2::blade<1, 2, 0>::canonical_type::dimensions) and
+        equal({0, 1, 2}, G2::blade<0, 1, 2>::canonical_type::dimensions));
+  };
+
+  "canonical form (G3)"_test = [] {
+    return expect(
+        equal({}, G3::blade<>::canonical_type::dimensions) and
+        equal({0}, G3::blade<0>::canonical_type::dimensions) and
+        equal({1}, G3::blade<1>::canonical_type::dimensions) and
+        equal({2}, G3::blade<2>::canonical_type::dimensions) and
+        equal({3}, G3::blade<3>::canonical_type::dimensions) and
+        equal({0, 1}, G3::blade<0, 1>::canonical_type::dimensions) and
+        equal({0, 2}, G3::blade<0, 2>::canonical_type::dimensions) and
+        equal({0, 3}, G3::blade<0, 3>::canonical_type::dimensions) and
+        equal({1, 2}, G3::blade<1, 2>::canonical_type::dimensions) and
+        equal({3, 1}, G3::blade<1, 3>::canonical_type::dimensions) and
+        equal({2, 3}, G3::blade<2, 3>::canonical_type::dimensions) and
+        equal({0, 1, 2}, G3::blade<0, 1, 2>::canonical_type::dimensions) and
+        equal({0, 3, 1}, G3::blade<0, 1, 3>::canonical_type::dimensions) and
+        equal({0, 2, 3}, G3::blade<0, 2, 3>::canonical_type::dimensions) and
+        equal({3, 2, 1}, G3::blade<1, 2, 3>::canonical_type::dimensions) and
+        equal({3, 2, 1}, G3::blade<3, 2, 1>::canonical_type::dimensions) and
+        equal({0, 1, 2, 3}, G3::blade<0, 1, 2, 3>::canonical_type::dimensions));
   };
 
   "sign conversion for canonical form"_test = [] {

--- a/test/line_test.cpp
+++ b/test/line_test.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <format>
+#include <ranges>
 #include <symengine/compat.hpp>
 #include <tuple>
 #include <type_traits>
@@ -91,5 +92,18 @@ auto main() -> int
     const auto l = GS3::line{"v1", "v2", "v3", "m1", "m2", "m3"};
 
     return expect(eq(std::format("{}", l.multivector()), std::format("{}", l)));
+  };
+
+  "join of two points is a line"_test = [] {
+    const auto p = G3::point{1, 1, 1, 0};
+    const auto q = G3::point{1, 1, -1, 0};
+
+    const auto l = p ^ q;
+
+    const auto scale = std::views::transform([alpha = l[1]](auto value) {
+      return value / alpha;
+    });
+
+    return expect(equal(std::array{0, 1, 0, 0, 0, 1}, l | scale));
   };
 }

--- a/test/sorted_canonical_blades_test.cpp
+++ b/test/sorted_canonical_blades_test.cpp
@@ -88,7 +88,7 @@ auto main() -> int
                 G3::blade<0, 2>,
                 G3::blade<0, 3>,
                 G3::blade<2, 3>,
-                G3::blade<1, 3>,  // TODO fix basis order
+                G3::blade<3, 1>,
                 G3::blade<1, 2>>,
             sorted_canonical_blades_t<
                 G3::blade<0, 1>,
@@ -104,9 +104,9 @@ auto main() -> int
         equal<
             type_list<
                 G3::blade<0, 2, 3>,
-                G3::blade<0, 1, 3>,  // TODO fix basis order
+                G3::blade<0, 3, 1>,
                 G3::blade<0, 1, 2>,
-                G3::blade<1, 2, 3>>,  // TODO fix basis order
+                G3::blade<3, 2, 1>>,
             sorted_canonical_blades_t<
                 G3::blade<0, 2, 3>,
                 G3::blade<0, 3, 1>,


### PR DESCRIPTION
Change blade basis dimension ordering. This new ordering is sometimes,
but not always, lexicographical. Using a different ordering reduces the
need to negate elements of line and plane types.

For grade 1 blades, canonical order is equivalent to lexicographic
order.

For grade 2 blades without a 0-dimensional basis (the projective
dimension), canonical order is equivalent to cyclic order:
* (1, 2) -> (1, 2)
* (1, 3) -> (3, 1)
* (2, 3) -> (2, 3)

For grade 2+ blades with a 0-dimensional basis (the projective
dimension), canonical order of [0, i...] is equivalent to
[0, canonical-order([i...])].

Change-Id: I44150916fdfcbbfdf2b7dac5088a6345046c391d