### PR TITLE
refactor `multivector` template parameters

### DIFF
--- a/rigid_geometric_algebra/BUILD.bazel
+++ b/rigid_geometric_algebra/BUILD.bazel
@@ -11,6 +11,7 @@ cc_library(
         "antiwedge.hpp",
         "blade.hpp",
         "blade_complement_type.hpp",
+        "blade_dimensions.hpp",
         "blade_fwd.hpp",
         "blade_ordering.hpp",
         "blade_sum.hpp",

--- a/rigid_geometric_algebra/algebra.hpp
+++ b/rigid_geometric_algebra/algebra.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rigid_geometric_algebra/blade_dimensions.hpp"
 #include "rigid_geometric_algebra/blade_fwd.hpp"
 #include "rigid_geometric_algebra/field.hpp"
 #include "rigid_geometric_algebra/geometric_fwd.hpp"
@@ -30,8 +31,8 @@ struct algebra
   template <std::size_t... Is>
   using blade = ::rigid_geometric_algebra::blade<algebra, Is...>;
 
-  template <class... Bs>
-  using multivector = ::rigid_geometric_algebra::multivector<algebra, Bs...>;
+  template <blade_dimensions... D>
+  using multivector = ::rigid_geometric_algebra::multivector<algebra, D...>;
 
   using scalar = ::rigid_geometric_algebra::scalar_type_t<algebra>;
 

--- a/rigid_geometric_algebra/blade_dimensions.hpp
+++ b/rigid_geometric_algebra/blade_dimensions.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "rigid_geometric_algebra/detail/contract.hpp"
+
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <utility>
+
+namespace rigid_geometric_algebra {
+
+/// dimensions of a blade
+/// @tparam N blade grade
+///
+/// Wrapper around `std::array` providing better deduction when used as a
+/// non-type template parameter.
+///
+template <std::size_t N>
+struct blade_dimensions : std::array<std::size_t, N>
+{
+  constexpr blade_dimensions(const std::array<std::size_t, N>& dims)
+      : std::array<std::size_t, N>{dims}
+  {}
+
+  template <std::integral... T>
+    requires (sizeof...(T) == N)
+  constexpr blade_dimensions(T... dims)
+      : std::array<std::size_t, N>{(
+            detail::precondition(std::in_range<std::size_t>(dims)),
+            static_cast<std::size_t>(dims))...}
+  {}
+};
+
+template <std::size_t N>
+// C-array necessary for deduction
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+blade_dimensions(const int (&)[N]) -> blade_dimensions<N>;
+
+template <std::integral... T>
+blade_dimensions(T...) -> blade_dimensions<sizeof...(T)>;
+
+}  // namespace rigid_geometric_algebra

--- a/rigid_geometric_algebra/blade_sum.hpp
+++ b/rigid_geometric_algebra/blade_sum.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include "rigid_geometric_algebra/canonical_type.hpp"
-#include "rigid_geometric_algebra/common_algebra_type.hpp"
 #include "rigid_geometric_algebra/detail/indices_array.hpp"
 #include "rigid_geometric_algebra/detail/type_list.hpp"
 #include "rigid_geometric_algebra/is_blade.hpp"
-#include "rigid_geometric_algebra/multivector_fwd.hpp"
+#include "rigid_geometric_algebra/multivector_type_from_blade_list.hpp"
 #include "rigid_geometric_algebra/sorted_canonical_blades.hpp"
 
 #include <array>
@@ -45,9 +44,8 @@ class blade_sum_fn
 public:
   template <
       detail::blade... Bs,
-      class A = common_algebra_type_t<Bs...>,
-      class V = typename sorted_canonical_blades_t<canonical_type_t<Bs>...>::
-          template insert_into_t<::rigid_geometric_algebra::multivector<A>>>
+      class V = multivector_type_from_blade_list_t<
+          sorted_canonical_blades_t<canonical_type_t<Bs>...>>>
     requires (sizeof...(Bs) != 0)
   static constexpr auto operator()(Bs&&... bs) -> V
   {

--- a/rigid_geometric_algebra/detail/derive_multivector_overload.hpp
+++ b/rigid_geometric_algebra/detail/derive_multivector_overload.hpp
@@ -9,7 +9,6 @@
 #include "rigid_geometric_algebra/detail/type_filter.hpp"
 #include "rigid_geometric_algebra/detail/type_product.hpp"
 #include "rigid_geometric_algebra/is_multivector.hpp"
-#include "rigid_geometric_algebra/multivector_fwd.hpp"
 #include "rigid_geometric_algebra/multivector_type_from_blade_list.hpp"
 #include "rigid_geometric_algebra/sorted_canonical_blades.hpp"
 #include "rigid_geometric_algebra/to_multivector.hpp"
@@ -66,13 +65,11 @@ class derive_multivector_overload
   template <template <class...> class list, class... Pairs, class V1, class V2>
     requires (sizeof...(Pairs) != 0)
   static constexpr auto
-  impl2(list<Pairs...>, V1&& v1, V2&& v2) -> typename sorted_canonical_blades_t<
-      std::invoke_result_t<
+  impl2(list<Pairs...>, V1&& v1, V2&& v2) -> multivector_type_from_blade_list_t<
+      sorted_canonical_blades_t<std::invoke_result_t<
           F,
           detail::copy_ref_qual_t<V1&&, typename Pairs::first_type>,
-          detail::copy_ref_qual_t<V2&&, typename Pairs::second_type>>...>::
-      template insert_into_t<
-          ::rigid_geometric_algebra::multivector<common_algebra_type_t<V1, V2>>>
+          detail::copy_ref_qual_t<V2&&, typename Pairs::second_type>>...>>
   {
     return blade_sum(F{}(
         get<typename Pairs::first_type>(std::forward<V1>(v1)),

--- a/rigid_geometric_algebra/detail/geometric_interface.hpp
+++ b/rigid_geometric_algebra/detail/geometric_interface.hpp
@@ -4,6 +4,7 @@
 #include "rigid_geometric_algebra/algebra_type.hpp"
 #include "rigid_geometric_algebra/detail/contract.hpp"
 #include "rigid_geometric_algebra/detail/decays_to.hpp"
+#include "rigid_geometric_algebra/detail/is_specialization_of.hpp"
 #include "rigid_geometric_algebra/glz_fwd.hpp"
 #include "rigid_geometric_algebra/is_multivector.hpp"
 

--- a/rigid_geometric_algebra/detail/multivector_sum.hpp
+++ b/rigid_geometric_algebra/detail/multivector_sum.hpp
@@ -4,7 +4,7 @@
 #include "rigid_geometric_algebra/detail/type_concat.hpp"
 #include "rigid_geometric_algebra/get_or.hpp"
 #include "rigid_geometric_algebra/is_multivector.hpp"
-#include "rigid_geometric_algebra/multivector_fwd.hpp"
+#include "rigid_geometric_algebra/multivector_type_from_blade_list.hpp"
 #include "rigid_geometric_algebra/sorted_canonical_blades.hpp"
 #include "rigid_geometric_algebra/to_multivector.hpp"
 #include "rigid_geometric_algebra/zero_constant_fwd.hpp"
@@ -22,20 +22,23 @@ public:
       detail::multivector V2,
       class A = common_algebra_type_t<V1, V2>>
   static constexpr auto
-  operator()(V1&& v1, V2&& v2) -> typename detail::type_concat_t<
-      typename std::remove_cvref_t<to_multivector_t<V1>>::blade_list_type,
-      typename std::remove_cvref_t<to_multivector_t<V2>>::blade_list_type>::
-      template insert_into_t<sorted_canonical_blades<>>::template insert_into_t<
-          ::rigid_geometric_algebra::multivector<A>>
+  operator()(V1&& v1, V2&& v2) -> multivector_type_from_blade_list_t<
+      typename detail::type_concat_t<
+          typename std::remove_cvref_t<to_multivector_t<V1>>::blade_list_type,
+          typename std::remove_cvref_t<to_multivector_t<V2>>::blade_list_type>::
+          template insert_into_t<sorted_canonical_blades<>>>
   {
     using result_blade_list_type = typename detail::type_concat_t<
         typename std::remove_cvref_t<to_multivector_t<V1>>::blade_list_type,
         typename std::remove_cvref_t<to_multivector_t<V2>>::blade_list_type>::
         template insert_into_t<sorted_canonical_blades<>>;
 
+    using multivector_type =
+        multivector_type_from_blade_list_t<result_blade_list_type>;
+
     return []<class... Ts, class V3, class V4>(
                detail::type_list<Ts...>, V3&& v3, V4&& v4) {
-      return ::rigid_geometric_algebra::multivector<A, Ts...>{(
+      return multivector_type{(
           get_or<Ts>(std::forward<V3>(v3), zero_constant<A>{}) +
           get_or<Ts>(std::forward<V4>(v4), zero_constant<A>{}))...};
     }(result_blade_list_type{},

--- a/rigid_geometric_algebra/is_multivector.hpp
+++ b/rigid_geometric_algebra/is_multivector.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "rigid_geometric_algebra/detail/is_specialization_of.hpp"
 #include "rigid_geometric_algebra/multivector_fwd.hpp"
 
 #include <type_traits>
@@ -12,7 +11,11 @@ namespace rigid_geometric_algebra {
 /// @{
 
 template <class T>
-struct is_multivector : detail::is_specialization_of<T, multivector>
+struct is_multivector : std::false_type
+{};
+
+template <class A, auto... D>
+struct is_multivector<multivector<A, D...>> : std::true_type
 {};
 
 template <class T>

--- a/rigid_geometric_algebra/multivector.hpp
+++ b/rigid_geometric_algebra/multivector.hpp
@@ -248,10 +248,10 @@ public:
   friend auto
   operator==(const multivector&, const multivector&) -> bool = default;
 
-  template <auto D2>
-    requires (not std::is_same_v<multivector, multivector<A, D2>>)
+  template <auto... D2>
+    requires (not std::is_same_v<multivector, multivector<A, D2...>>)
   friend auto
-  operator==(const multivector&, const multivector<A, D2>&) -> bool = delete;
+  operator==(const multivector&, const multivector<A, D2...>&) -> bool = delete;
 
   /// @}
 };

--- a/rigid_geometric_algebra/multivector_fwd.hpp
+++ b/rigid_geometric_algebra/multivector_fwd.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
-#include "rigid_geometric_algebra/algebra_type.hpp"
+#include "rigid_geometric_algebra/blade_dimensions.hpp"
 #include "rigid_geometric_algebra/is_algebra.hpp"
-#include "rigid_geometric_algebra/is_canonical_blade_order.hpp"
 
-#include <type_traits>
 namespace rigid_geometric_algebra {
 
-template <class A, class... Bs>
-  requires is_algebra_v<A> and (is_canonical_blade_order<Bs...>()) and
-           (std::is_same_v<A, algebra_type_t<Bs>> and ...)
+template <class A, blade_dimensions... D>
+  requires is_algebra_v<A>
 class multivector;
 
 }

--- a/rigid_geometric_algebra/multivector_type_from_blade_list.hpp
+++ b/rigid_geometric_algebra/multivector_type_from_blade_list.hpp
@@ -14,9 +14,10 @@ struct multivector_type_from_blade_list
 {};
 
 template <template <class...> class list, class... Bs>
+  requires (sizeof...(Bs) != 0)
 struct multivector_type_from_blade_list<list<Bs...>>
 {
-  using type = multivector<common_algebra_type_t<Bs...>, Bs...>;
+  using type = multivector<common_algebra_type_t<Bs...>, Bs::dimensions...>;
 };
 
 template <class BladeList>

--- a/rigid_geometric_algebra/point.hpp
+++ b/rigid_geometric_algebra/point.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "rigid_geometric_algebra/blade_fwd.hpp"
 #include "rigid_geometric_algebra/detail/geometric_interface.hpp"
 #include "rigid_geometric_algebra/glz_fwd.hpp"
 #include "rigid_geometric_algebra/multivector_fwd.hpp"
@@ -18,9 +17,7 @@ template <class A>
   requires is_algebra_v<A>
 using point_multivector_type_t =
     decltype([]<std::size_t... Is>(std::index_sequence<Is...>)
-                 -> ::rigid_geometric_algebra::multivector<
-                     A,
-                     ::rigid_geometric_algebra::blade<A, Is>...> {
+                 -> ::rigid_geometric_algebra::multivector<A, { Is }...> {
       return {};
     }(std::make_index_sequence<algebra_dimension_v<A>>{}));
 

--- a/rigid_geometric_algebra/rigid_geometric_algebra.hpp
+++ b/rigid_geometric_algebra/rigid_geometric_algebra.hpp
@@ -18,6 +18,7 @@ namespace rigid_geometric_algebra {}  // namespace rigid_geometric_algebra
 #include "rigid_geometric_algebra/antiwedge.hpp"
 #include "rigid_geometric_algebra/blade.hpp"
 #include "rigid_geometric_algebra/blade_complement_type.hpp"
+#include "rigid_geometric_algebra/blade_dimensions.hpp"
 #include "rigid_geometric_algebra/blade_sum.hpp"
 #include "rigid_geometric_algebra/blade_type_from.hpp"
 #include "rigid_geometric_algebra/canonical_type.hpp"

--- a/rigid_geometric_algebra/to_multivector.hpp
+++ b/rigid_geometric_algebra/to_multivector.hpp
@@ -18,7 +18,7 @@ class fn
   template <detail::blade B>
   static constexpr auto
   impl(detail::priority<1>, B&& b) -> ::rigid_geometric_algebra::
-      multivector<algebra_type_t<B>, canonical_type_t<B>>
+      multivector<algebra_type_t<B>, canonical_type_t<B>::dimensions>
   {
     return {std::forward<B>(b).canonical()};
   }

--- a/test/blade_sum_test.cpp
+++ b/test/blade_sum_test.cpp
@@ -52,7 +52,7 @@ auto main() -> int
     const auto b = G2::blade<1, 2>{4};
     const auto v = blade_sum(a, b);
 
-    return expect(eq(G2::multivector<G2::blade<0>, G2::blade<1, 2>>{3, 4}, v));
+    return expect(eq(G2::multivector<{0}, {1, 2}>{3, 4}, v));
   };
 
   "multiple blades with same canonical form"_test = [] {
@@ -61,6 +61,6 @@ auto main() -> int
     const auto v = blade_sum(a, b);
 
     return expect(
-        eq(G2::multivector<G2::blade<1, 2>>{a.coefficient - b.coefficient}, v));
+        eq(G2::multivector<{1, 2}>{a.coefficient - b.coefficient}, v));
   };
 }

--- a/test/detail/multivector_promotable_test.cpp
+++ b/test/detail/multivector_promotable_test.cpp
@@ -11,7 +11,7 @@ auto main() -> int
   static_assert(multivector_promotable<G2::blade<0>>);
   static_assert(multivector_promotable<G2::blade<0, 1, 2>>);
   static_assert(multivector_promotable<G2::multivector<>>);
-  static_assert(multivector_promotable<G2::multivector<G2::blade<0, 1, 2>>>);
+  static_assert(multivector_promotable<G2::multivector<{0, 1, 2}>>);
 
   static_assert(multivector_promotable<const G2::blade<>>);
   static_assert(multivector_promotable<G2::blade<>&>);

--- a/test/get_or_test.cpp
+++ b/test/get_or_test.cpp
@@ -19,13 +19,17 @@ auto main() -> int
 
   "get_or invocable on tuples"_test = [] {
     return expect(
-        std::
-            is_invocable_v<decltype(get_or<B0>), G2::multivector<B0>, dummy> and
-        std::
-            is_invocable_v<decltype(get_or<B0>), G2::multivector<B1>, dummy> and
         std::is_invocable_v<
             decltype(get_or<B0>),
-            G2::multivector<B0, B1>,
+            G2::multivector<B0::dimensions>,
+            dummy> and
+        std::is_invocable_v<
+            decltype(get_or<B0>),
+            G2::multivector<B1::dimensions>,
+            dummy> and
+        std::is_invocable_v<
+            decltype(get_or<B0>),
+            G2::multivector<B0::dimensions, B1::dimensions>,
             dummy>);
   };
 
@@ -34,54 +38,37 @@ auto main() -> int
   };
 
   "get_or return type"_test = [] {
+    using V = G2::multivector<B0::dimensions>;
     return expect(
         std::is_same_v<
             B0&,
-            std::invoke_result_t<
-                decltype(get_or<B0>),
-                G2::multivector<B0>&,
-                dummy>> and
+            std::invoke_result_t<decltype(get_or<B0>), V&, dummy>> and
         std::is_same_v<
             const B0&,
-            std::invoke_result_t<
-                decltype(get_or<B0>),
-                const G2::multivector<B0>&,
-                dummy>> and
+            std::invoke_result_t<decltype(get_or<B0>), const V&, dummy>> and
         std::is_same_v<
             B0&&,
-            std::invoke_result_t<
-                decltype(get_or<B0>),
-                G2::multivector<B0>&&,
-                dummy>> and
+            std::invoke_result_t<decltype(get_or<B0>), V&&, dummy>> and
         std::is_same_v<
             const B0&&,
-            std::invoke_result_t<
-                decltype(get_or<B0>),
-                const G2::multivector<B0>&&,
-                dummy>> and
+            std::invoke_result_t<decltype(get_or<B0>), const V&&, dummy>> and
         std::is_same_v<
             dummy&,
-            std::invoke_result_t<
-                decltype(get_or<B1>),
-                G2::multivector<B0>&,
-                dummy&>> and
+            std::invoke_result_t<decltype(get_or<B1>), V&, dummy&>> and
         std::is_same_v<
             const dummy&,
             std::invoke_result_t<
                 decltype(get_or<B1>),
-                const G2::multivector<B0>&,
+                const V&,
                 const dummy&>> and
         std::is_same_v<
             dummy&&,
-            std::invoke_result_t<
-                decltype(get_or<B1>),
-                G2::multivector<B0>&&,
-                dummy&&>> and
+            std::invoke_result_t<decltype(get_or<B1>), V&&, dummy&&>> and
         std::is_same_v<
             const dummy&&,
             std::invoke_result_t<
                 decltype(get_or<B1>),
-                const G2::multivector<B0>&&,
+                const V&&,
                 const dummy&&>>);
   };
 }

--- a/test/get_test.cpp
+++ b/test/get_test.cpp
@@ -18,13 +18,19 @@ auto main() -> int
 
   "get invocable on tuples"_test = [] {
     return expect(
-        std::is_invocable_v<decltype(get<B0>), multivector<G2, B0>> and
-        std::is_invocable_v<decltype(get<B0>), multivector<G2, B0, B1>>);
+        std::is_invocable_v<
+            decltype(get<B0>),
+            multivector<G2, B0::dimensions>> and
+        std::is_invocable_v<
+            decltype(get<B0>),
+            multivector<G2, B0::dimensions, B1::dimensions>>);
   };
 
   "get not invocable on tuples missing element"_test = [] {
     return expect(
-        (not std::is_invocable_v<decltype(get<B1>), multivector<G2, B0>>));
+        (not std::is_invocable_v<
+            decltype(get<B1>),
+            multivector<G2, B0::dimensions>>));
   };
 
   "get not invocable on tuples"_test = [] {
@@ -36,22 +42,15 @@ auto main() -> int
   };
 
   "get return type"_test = [] {
+    using V = multivector<G2, {B0::dimensions}>;
     return expect(
-        std::is_same_v<
-            B0&,
-            std::invoke_result_t<decltype(get<B0>), multivector<G2, B0>&>> and
+        std::is_same_v<B0&, std::invoke_result_t<decltype(get<B0>), V&>> and
         std::is_same_v<
             const B0&,
-            std::invoke_result_t<
-                decltype(get<B0>),
-                const multivector<G2, B0>&>> and
-        std::is_same_v<
-            B0&&,
-            std::invoke_result_t<decltype(get<B0>), multivector<G2, B0>&&>> and
+            std::invoke_result_t<decltype(get<B0>), const V&>> and
+        std::is_same_v<B0&&, std::invoke_result_t<decltype(get<B0>), V&&>> and
         std::is_same_v<
             const B0&&,
-            std::invoke_result_t<
-                decltype(get<B0>),
-                const multivector<G2, B0>&&>>);
+            std::invoke_result_t<decltype(get<B0>), const V&&>>);
   };
 }

--- a/test/multivector_test.cpp
+++ b/test/multivector_test.cpp
@@ -46,7 +46,7 @@ auto main() -> int
 
   "get return type"_test = [] {
     using B = G2::blade<1>;
-    using V = multivector<G2, B>;
+    using V = multivector<G2, B::dimensions>;
 
     using ::rigid_geometric_algebra::get;
     using F = decltype(get<B>);
@@ -62,8 +62,8 @@ auto main() -> int
     using B1 = G2::blade<1>;
     using B2 = G2::blade<2>;
 
-    using V1 = multivector<G2, B1>;
-    using V2 = multivector<G2, B1, B2>;
+    using V1 = multivector<G2, B1::dimensions>;
+    using V2 = multivector<G2, B1::dimensions, B2::dimensions>;
 
     const auto v1 = V1{B1{1}};
     const auto v2 = V2{v1};
@@ -75,59 +75,54 @@ auto main() -> int
 
   "addition of multivectors with disjoint blade types"_test = [] {
     return expect(eq(
-        multivector<G2, G2::blade<0>, G2::blade<1>>{1, 2},
-        multivector<G2, G2::blade<0>>{1} + multivector<G2, G2::blade<1>>{2}));
+        multivector<G2, {0}, {1}>{1, 2},
+        multivector<G2, {0}>{1} + multivector<G2, {1}>{2}));
   };
 
   "addition of multivectors with overlapping blade types"_test = [] {
     return expect(eq(
-        multivector<G2, G2::blade<0>, G2::blade<1>, G2::blade<2>>{1, 5, 4},
-        multivector<G2, G2::blade<0>, G2::blade<1>>{1, 2} +
-            multivector<G2, G2::blade<1>, G2::blade<2>>{3, 4}));
+        multivector<G2, {0}, {1}, {2}>{1, 5, 4},
+        multivector<G2, {0}, {1}>{1, 2} + multivector<G2, {1}, {2}>{3, 4}));
   };
 
   "addition of multivectors with same blade types"_test = [] {
     return expect(eq(
-        multivector<G2, G2::blade<0>, G2::blade<1>, G2::blade<2>>{5, 7, 9},
-        multivector<G2, G2::blade<0>, G2::blade<1>, G2::blade<2>>{1, 2, 3} +
-            multivector<G2, G2::blade<0>, G2::blade<1>, G2::blade<2>>{
-                4, 5, 6}));
+        multivector<G2, {0}, {1}, {2}>{5, 7, 9},
+        multivector<G2, {0}, {1}, {2}>{1, 2, 3} +
+            multivector<G2, {0}, {1}, {2}>{4, 5, 6}));
   };
 
   "subtraction of multivectors with disjoint blade types"_test = [] {
     return expect(eq(
-        multivector<G2, G2::blade<0>, G2::blade<1>>{1, -2},
-        multivector<G2, G2::blade<0>>{1} - multivector<G2, G2::blade<1>>{2}));
+        multivector<G2, {0}, {1}>{1, -2},
+        multivector<G2, {0}>{1} - multivector<G2, {1}>{2}));
   };
 
   "subtraction of multivectors with overlapping blade types"_test = [] {
     return expect(eq(
-        multivector<G2, G2::blade<0>, G2::blade<1>, G2::blade<2>>{1, -1, -4},
-        multivector<G2, G2::blade<0>, G2::blade<1>>{1, 2} -
-            multivector<G2, G2::blade<1>, G2::blade<2>>{3, 4}));
+        multivector<G2, {0}, {1}, {2}>{1, -1, -4},
+        multivector<G2, {0}, {1}>{1, 2} - multivector<G2, {1}, {2}>{3, 4}));
   };
 
   "subtraction of multivectors with same blade types"_test = [] {
     return expect(eq(
-        multivector<G2, G2::blade<0>, G2::blade<1>, G2::blade<2>>{-3, -3, -3},
-        multivector<G2, G2::blade<0>, G2::blade<1>, G2::blade<2>>{1, 2, 3} -
-            multivector<G2, G2::blade<0>, G2::blade<1>, G2::blade<2>>{
-                4, 5, 6}));
+        multivector<G2, {0}, {1}, {2}>{-3, -3, -3},
+        multivector<G2, {0}, {1}, {2}>{1, 2, 3} -
+            multivector<G2, {0}, {1}, {2}>{4, 5, 6}));
   };
 
   "scalar multiplication of a multivector"_test = [] {
     return expect(eq(
-        multivector<G2, G2::blade<0>, G2::blade<1>, G2::blade<2>>{2, 4, 6},
-        2 * multivector<G2, G2::blade<0>, G2::blade<1>, G2::blade<2>>{
-                1, 2, 3}));
+        multivector<G2, {0}, {1}, {2}>{2, 4, 6},
+        2 * multivector<G2, {0}, {1}, {2}>{1, 2, 3}));
   };
 
   "addition of multivector with blade"_test = [] {
     return expect(
-        eq(multivector<G2, G2::blade<0>, G2::blade<1>>{1, 2},
-           multivector<G2, G2::blade<0>>{1} + G2::blade<1>{2}) and
-        eq(multivector<G2, G2::blade<0>, G2::blade<1>>{1, 2},
-           G2::blade<1>{2} + multivector<G2, G2::blade<0>>{1}));
+        eq(multivector<G2, {0}, {1}>{1, 2},
+           multivector<G2, {0}>{1} + G2::blade<1>{2}) and
+        eq(multivector<G2, {0}, {1}>{1, 2},
+           G2::blade<1>{2} + multivector<G2, {0}>{1}));
   };
 
   "multivector wedge product"_test = [] {
@@ -165,13 +160,13 @@ auto main() -> int
 
   "comparison of different multivector types not hard error"_test = [] {
     using V1 = G2::multivector<>;
-    using V2 = G2::multivector<G2::blade<>, G2::blade<1>>;
+    using V2 = G2::multivector<{}, {1}>;
 
     return expect(not std::is_invocable_v<std::equal_to<>, V1, V2>);
   };
 
   "multivector types usable with structured bindings"_test = [] {
-    const auto v = G2::multivector<G2::blade<>, G2::blade<1>>{0, 1};
+    const auto v = G2::multivector<{}, {1}>{0, 1};
     const auto [a, b] = v;
 
     return expect(eq(get<0>(v), a) and eq(get<1>(v), b));

--- a/test/point_test.cpp
+++ b/test/point_test.cpp
@@ -123,11 +123,6 @@ auto main() -> int
       return eq(b1, b2) or eq(expand(b1.coefficient), expand(b2.coefficient));
     };
 
-    //[[maybe_unused]] int x = (p^q).multivector();
-
-    // using ::rigid_geometric_algebra::multivector2;
-    // [[maybe_unused]] int y = multivector2<GS3, {1}, {2}, {1, 2}>{};
-
     return expect(compare_each_element(l, p ^ q, cmp));
   };
 

--- a/test/to_multivector_test.cpp
+++ b/test/to_multivector_test.cpp
@@ -13,9 +13,7 @@ auto main() -> int
 
   "to_multivector(blade)"_test = [] {
     return expect(
-        eq(G2::multivector<G2::blade<1, 2>>{1},
-           to_multivector(G2::blade<1, 2>{1})) and
-        eq(G2::multivector<G2::blade<1, 2>>{1},
-           -to_multivector(G2::blade<2, 1>{1})));
+        eq(G2::multivector<{1, 2}>{1}, to_multivector(G2::blade<1, 2>{1})) and
+        eq(G2::multivector<{1, 2}>{1}, -to_multivector(G2::blade<2, 1>{1})));
   };
 }


### PR DESCRIPTION
Replace `blade` template parameters in `multivector` with
`blade_dimensions` non-type template parameters. This makes it easier to
determine the `blade` types in a `multivector` in error messages by
removing the repeated `algebra` type.

Change-Id: Ifbff5948493ace350a7736179961ac55e4f6a20c